### PR TITLE
Build image in eu-central-1

### DIFF
--- a/spacelift.pkr.hcl
+++ b/spacelift.pkr.hcl
@@ -3,6 +3,7 @@ variable "ami_regions" {
   default = [
     "us-east-1",
     "ap-southeast-1",
+    "eu-central-1",
     "eu-west-1",
   ]
 }


### PR DESCRIPTION
## Description of the change

We'd like to use https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2 in eu-central-1. This seems like the first step to do so:

1. Upload this AMI to eu-central-1
2. Pass in `ami_id` to the module
3. (Optional) Update the module so it hardcodes a map of region to AMI ID, so customers don't have to figure out the right AMI ID themselves.
4. (Optional) Publish the AMI IDs in a list somewhere

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
