### PR TITLE
feat: updates the Packer configuration to be more flexible

### DIFF
--- a/spacelift.pkr.hcl
+++ b/spacelift.pkr.hcl
@@ -1,3 +1,8 @@
+variable "ami_name" {
+  type    = string
+  default = "spacelift-{{timestamp}}"
+}
+
 variable "ami_regions" {
   type = list(string)
   default = [
@@ -12,21 +17,75 @@ variable "base_ami" {
   type = string
 }
 
+variable "ami_groups" {
+  type    = list(string)
+  default = ["all"]
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.micro"
+}
+
+variable "encrypt_boot" {
+  type    = bool
+  default = true
+}
+
+variable "shared_credentials_file" {
+  type    = string
+  default = null
+}
+
+variable "subnet_filter" {
+  type    = map(string)
+  default = null
+}
+
+variable "additional_tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "vpc_id" {
+  type    = string
+  default = null
+}
+
 source "amazon-ebs" "spacelift" {
   source_ami = var.base_ami
 
-  instance_type = "t2.micro"
-  ssh_username  = "ec2-user"
-
-  ami_name    = "spacelift-{{timestamp}}"
+  ami_name    = var.ami_name
   ami_regions = var.ami_regions
-  ami_groups  = ["all"]
+  ami_groups  = var.ami_groups
 
-  tags = {
-    Name    = "Spacelift AMI"
-    Purpose = "Spacelift"
-    BaseAMI = var.base_ami
+  shared_credentials_file = var.shared_credentials_file
+  encrypt_boot            = var.encrypt_boot
+  instance_type           = var.instance_type
+  ssh_username            = "ec2-user"
+
+  vpc_id = var.vpc_id
+  region = var.region
+
+  dynamic "subnet_filter" {
+    for_each = var.subnet_filter == null ? [] : [1]
+    content {
+      filters = var.subnet_filter
+      most_free = true
+      random = false
+    }
   }
+
+  tags = merge(var.additional_tags, {
+    Name      = "Spacelift AMI"
+    Purpose   = "Spacelift"
+    BaseAMI   = var.base_ami
+  })
 }
 
 build {


### PR DESCRIPTION
## Description of the change

* Adds the ability to further customize the AWS AMI that is created. 
* Adds the ability to deploy the packer build into a VPC / Subnet group via `subnet_filter`, `vpc_id`, and `region` 
* Defaults the AMI to being encrypted via `encrypt_boot = true`: https://www.packer.io/docs/builders/amazon/ebs#encrypt_boot
* Changes default build instance to a `t3.micro`

## Type of change

- [x] New feature (non-breaking change that adds functionality);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
