### PR TITLE
Add `source_ami_filter` ability

### DIFF
--- a/spacelift.pkr.hcl
+++ b/spacelift.pkr.hcl
@@ -29,7 +29,7 @@ variable "source_ami_filter_filters" {
 
 variable "source_ami_filter_owners" {
   type    = list(string)
-  default = 137112412989
+  default = ["137112412989"]
 }
 
 variable "source_ami_filter_most_recent" {

--- a/spacelift.pkr.hcl
+++ b/spacelift.pkr.hcl
@@ -79,7 +79,7 @@ variable "vpc_id" {
 
 source "amazon-ebs" "spacelift" {
   source_ami = var.base_ami
-  
+
   dynamic "source_ami_filter" {
     for_each = var.base_ami == null ? [1] : []
     content {

--- a/spacelift.pkr.hcl
+++ b/spacelift.pkr.hcl
@@ -18,7 +18,7 @@ variable "base_ami" {
   default = null
 }
 
-variable "source_ami_filter_filters" {
+variable "source_ami_filters" {
   type    = map(string)
   default = {
     virtualization-type = "hvm"
@@ -27,12 +27,12 @@ variable "source_ami_filter_filters" {
   }
 }
 
-variable "source_ami_filter_owners" {
+variable "source_ami_owners" {
   type    = list(string)
   default = ["137112412989"]
 }
 
-variable "source_ami_filter_most_recent" {
+variable "source_ami_most_recent" {
   type    = bool
   default = true
 }
@@ -83,9 +83,9 @@ source "amazon-ebs" "spacelift" {
   dynamic "source_ami_filter" {
     for_each = var.base_ami == null ? [1] : []
     content {
-      filters = var.source_ami_filter_filters
-      owners = var.source_ami_filter_owners
-      most_recent = var.source_ami_filter_most_recent
+      filters     = var.source_ami_filters
+      owners      = var.source_ami_owners
+      most_recent = var.source_ami_most_recent
     }
   }
 

--- a/spacelift.pkr.hcl
+++ b/spacelift.pkr.hcl
@@ -29,7 +29,7 @@ variable "source_ami_filters" {
 
 variable "source_ami_owners" {
   type    = list(string)
-  default = ["137112412989"]
+  default = ["137112412989"] # defaults to Amazon for Amazon Linux, see https://docs.aws.amazon.com/AmazonECR/latest/userguide/amazon_linux_container_image.html
 }
 
 variable "source_ami_most_recent" {


### PR DESCRIPTION
## Description of the change

Closes https://github.com/spacelift-io/spacelift-worker-image/issues/4

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected;

```shell
# clone
git@github.com:spacelift-io/spacelift-worker-image.git
cd spacelift-worker-image
# download the `spacelift.pkr.hcl` in this pr
curl -s https://raw.githubusercontent.com/nitrocode/spacelift-worker-image/patch-1/spacelift.pkr.hcl -o spacelift.pkr.hcl
# build image in us-east-2 and do not copy image to other regions
packer build \
  -var='region=us-east-2' \
  -var='ami_regions=null' \
  -var='ami_groups=null' \
  spacelift.pkr.hcl
```

output

```
    amazon-ebs.spacelift: Stopping instance
==> amazon-ebs.spacelift: Waiting for the instance to stop...
==> amazon-ebs.spacelift: Creating AMI abKhrsp from instance i-snip
    amazon-ebs.spacelift: AMI: ami-snip
==> Wait completed after 12 minutes 37 seconds

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.spacelift: AMIs were created:
us-east-2: ami-snip
```

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
