### PR TITLE
security: `ami_groups` should not default to all

### DIFF
--- a/spacelift.pkr.hcl
+++ b/spacelift.pkr.hcl
@@ -19,7 +19,7 @@ variable "base_ami" {
 
 variable "ami_groups" {
   type    = list(string)
-  default = ["all"]
+  default = null
 }
 
 variable "instance_type" {


### PR DESCRIPTION
## Description of the change

The `ami_groups` currently defaults to `["all"]` which by default tries to make the AMI publicly accessible which is a security issue. This sets the variable to `null` to prevent this default unless explicitly specified.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
