### PR TITLE
Add ability to publish to a shared image gallery

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -13,3 +13,9 @@ packer build spacelift.pkr.hcl
 Override the defaults using `-var="location=westeurope"`
 
 The variables are located in the `spacelift.pkr.hcl` file.
+
+### Shared Image Gallery
+
+By default, the template creates a Managed image in the resource group defined by the `image_resource_group`
+variable. The image can optionally be published to a shared image gallery by setting the `gallery_*`
+variables.

--- a/azure/spacelift.pkr.hcl
+++ b/azure/spacelift.pkr.hcl
@@ -26,6 +26,31 @@ variable "image_resource_group" {
   type = string
 }
 
+variable "gallery_resource_group" {
+  type    = string
+  default = null
+}
+
+variable "gallery_name" {
+  type    = string
+  default = null
+}
+
+variable "gallery_image_name" {
+  type    = string
+  default = null
+}
+
+variable "gallery_image_version" {
+  type    = string
+  default = null
+}
+
+variable "gallery_replication_regions" {
+  type    = list(string)
+  default = null
+}
+
 variable "source_image_publisher" {
   type    = string
   default = "Canonical"
@@ -70,6 +95,18 @@ source "azure-arm" "spacelift" {
 
   managed_image_name                = var.image_name
   managed_image_resource_group_name = var.image_resource_group
+
+  dynamic "shared_image_gallery_destination" {
+    for_each = var.gallery_name != null ? [0] : []
+    content {
+      subscription         = var.subscription_id
+      resource_group       = var.gallery_resource_group
+      gallery_name         = var.gallery_name
+      image_name           = var.gallery_image_name
+      image_version        = var.gallery_image_version
+      replication_regions  = var.gallery_replication_regions
+    }
+  }
 
   os_type = "Linux"
 


### PR DESCRIPTION
## Description of the change

Once the image is published to a shared image gallery, we can then use that as a source to publish to the Azure Marketplace.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
