### PR TITLE
Fix packer build resource group

### DIFF
--- a/azure/spacelift.pkr.hcl
+++ b/azure/spacelift.pkr.hcl
@@ -68,7 +68,7 @@ variable "source_image_sku" {
 
 variable "location" {
   type    = string
-  default = "West Europe"
+  default = ""
 }
 
 variable "vm_size" {
@@ -114,7 +114,7 @@ source "azure-arm" "spacelift" {
   image_offer     = var.source_image_offer
   image_sku       = var.source_image_sku
   
-  resource_group_name = var.packer_work_group
+  build_resource_group_name = var.packer_work_group
 
   location = var.location
   vm_size  = var.vm_size


### PR DESCRIPTION
## Description of the change

I had accidentally set the `resource_group_name`, which is the group containing the storage account when capturing to a VHD. What I was meaning to set was `build_resource_group_name`, which specifies the group for Packer to use to create its temp resources.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
