### PR TITLE
Use kernel 5.10

### DIFF
--- a/aws/spacelift.pkr.hcl
+++ b/aws/spacelift.pkr.hcl
@@ -29,7 +29,7 @@ variable "source_ami_filters" {
   type    = map(string)
   default = {
     virtualization-type = "hvm"
-    name                = "amzn2-ami-hvm-2*-x86_64-gp2"
+    name                = "amzn2-ami-kernel-5.10-hvm-2*-x86_64-gp2"
     root-device-type    = "ebs"
   }
 }


### PR DESCRIPTION
## Description of the change

Use kernel 5.10

https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-linux-2-ami-kernel-5-10/

```
aws ec2 describe-images --owners amazon --filters "Name=name,Values=amzn2*kernel*" --query 'sort_by(Images, &CreationDate)[].Name'
```

[gravitational/teleport](https://github.com/gravitational/teleport) in particular requires the latest kernel to allow ssh.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
