### PR TITLE
Update gvisor installation to fetch newest version

### DIFF
--- a/aws/scripts/04-gvisor.sh
+++ b/aws/scripts/04-gvisor.sh
@@ -1,11 +1,15 @@
 # This script installs the gVisor.
 set -e
 
-URL=https://storage.googleapis.com/gvisor/releases/release/latest
+ARCH=$(uname -m)
+URL=https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}
 
-wget ${URL}/runsc -P /tmp
-sudo mv /tmp/runsc /usr/local/bin
-sudo chmod a+rx /usr/local/bin/runsc
+wget ${URL}/runsc ${URL}/runsc.sha512 ${URL}/containerd-shim-runsc-v1 ${URL}/containerd-shim-runsc-v1.sha512
+sha512sum -c runsc.sha512 -c containerd-shim-runsc-v1.sha512
+rm -f *.sha512
+
+chmod a+rx runsc containerd-shim-runsc-v1
+sudo mv runsc containerd-shim-runsc-v1 /usr/local/bin
 
 sudo /usr/local/bin/runsc install -- --fsgofer-host-uds
 sudo systemctl restart docker

--- a/azure/scripts/04-gvisor.sh
+++ b/azure/scripts/04-gvisor.sh
@@ -1,11 +1,15 @@
 # This script installs the gVisor.
 set -e
 
-URL=https://storage.googleapis.com/gvisor/releases/release/latest
+ARCH=$(uname -m)
+URL=https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}
 
-wget ${URL}/runsc -P /tmp
-sudo mv /tmp/runsc /usr/local/bin
-sudo chmod a+rx /usr/local/bin/runsc
+wget ${URL}/runsc ${URL}/runsc.sha512 ${URL}/containerd-shim-runsc-v1 ${URL}/containerd-shim-runsc-v1.sha512
+sha512sum -c runsc.sha512 -c containerd-shim-runsc-v1.sha512
+rm -f *.sha512
+
+chmod a+rx runsc containerd-shim-runsc-v1
+sudo mv runsc containerd-shim-runsc-v1 /usr/local/bin
 
 sudo /usr/local/bin/runsc install -- --fsgofer-host-uds
 sudo systemctl restart docker

--- a/gcp/scripts/04-gvisor.sh
+++ b/gcp/scripts/04-gvisor.sh
@@ -1,11 +1,15 @@
 # This script installs the gVisor.
 set -e
 
-URL=https://storage.googleapis.com/gvisor/releases/release/latest
+ARCH=$(uname -m)
+URL=https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}
 
-wget ${URL}/runsc -P /tmp
-sudo mv /tmp/runsc /usr/local/bin
-sudo chmod a+rx /usr/local/bin/runsc
+wget ${URL}/runsc ${URL}/runsc.sha512 ${URL}/containerd-shim-runsc-v1 ${URL}/containerd-shim-runsc-v1.sha512
+sha512sum -c runsc.sha512 -c containerd-shim-runsc-v1.sha512
+rm -f *.sha512
+
+chmod a+rx runsc containerd-shim-runsc-v1
+sudo mv runsc containerd-shim-runsc-v1 /usr/local/bin
 
 sudo /usr/local/bin/runsc install -- --fsgofer-host-uds
 sudo systemctl restart docker


### PR DESCRIPTION
## Description of the change

Turned out we are running an old version of gvisor. For that we follow the suggested way of installing it from official docs: https://gvisor.dev/docs/user_guide/install/

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [x] Changes have been reviewed by at least one other engineer;
