### PR TITLE
Build public AMIs in GitHub instead of AWS

### DIFF
--- a/.github/workflows/build_aws_scheduled.yml
+++ b/.github/workflows/build_aws_scheduled.yml
@@ -1,0 +1,36 @@
+name: AWS AMI scheduled publish
+
+on:
+  schedule:
+    # Every Sunday at 23:00 UTC
+    - cron: "00 23 * * 0"
+
+jobs:
+  build:
+    name: Build the AWS AMI using Packer
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@main
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-duration-seconds: 3600
+
+      - name: Validate the Packer template
+        uses: hashicorp/packer-github-actions@master
+        with:
+          command: validate
+          target: aws.pkr.hcl
+
+      - name: Build the AWS AMI using Packer
+        uses: hashicorp/packer-github-actions@master
+        with:
+          command: build
+          target: aws.pkr.hcl

--- a/.github/workflows/build_gcp_azure_manual.yml
+++ b/.github/workflows/build_gcp_azure_manual.yml
@@ -1,0 +1,114 @@
+name: AWS & GCP AMI manual publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build the AWS & GCP AMIs using Packer
+    strategy:
+      matrix:
+        cloud: [azure, gcp]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      # GCP
+      PKR_VAR_project_id: spacelift-workers
+      PKR_VAR_account_file: ./gcp.json
+      PKR_VAR_image_base_name: spacelift-worker
+      PKR_VAR_image_family: spacelift-worker
+      # Azure
+      PKR_VAR_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+      PKR_VAR_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      PKR_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      PKR_VAR_image_resource_group: rg-worker_images-public-westeurope
+      PKR_VAR_packer_work_group: rg-worker_images_packer-public-westeurope
+      PKR_VAR_gallery_resource_group: rg-worker_images-public-westeurope
+      PKR_VAR_gallery_name: worker_images_public
+      PKR_VAR_gallery_image_name: ubuntu_20_04
+      PKR_VAR_gallery_replication_regions: '["westeurope"]'
+      PKR_VAR_gallery_image_version: 1.0.${{ github.run_number }}
+
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@main
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-duration-seconds: 3600
+
+      - name: Set up Google Cloud SDK
+        if: matrix.cloud == 'gcp'
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Create account file for GCP
+        if: matrix.cloud == 'gcp'
+        run: |
+          echo '${{ secrets.GCP_CREDENTIALS_JSON }}' > ${{ env.PKR_VAR_account_file }}
+
+      - name: Authenticate with GCP
+        if: matrix.cloud == 'gcp'
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+
+      - name: Export suffix for GCP
+        if: matrix.cloud == 'gcp'
+        run: |
+          echo "PKR_VAR_suffix=$(date +%s)-$(cat /dev/urandom | tr -dc 'a-z0-9' | head -c 8)" >> $GITHUB_ENV
+
+      - name: Validate the Packer template
+        uses: hashicorp/packer-github-actions@master
+        with:
+          command: validate
+          target: ${{ matrix.cloud }}.pkr.hcl
+
+      - name: Azure => Build the AMI using Packer
+        uses: hashicorp/packer-github-actions@master
+        if: matrix.cloud == 'azure'
+        with:
+          command: build
+          target: azure.pkr.hcl
+      
+      - name: GCP => Build the AMI using Packer for US
+        uses: hashicorp/packer-github-actions@master
+        if: matrix.cloud == 'gcp'
+        env:
+          PKR_VAR_image_storage_location: us
+          PKR_VAR_zone: us-central1-a
+        with:
+          command: build
+          target: gcp.pkr.hcl
+
+      - name: GCP => Build the AMI using Packer for EU
+        uses: hashicorp/packer-github-actions@master
+        if: matrix.cloud == 'gcp'
+        env:
+          PKR_VAR_image_storage_location: ez
+          PKR_VAR_zone: europe-west1-d
+        with:
+          command: build
+          target: gcp.pkr.hcl
+
+      - name: GCP => Build the AMI using Packer for Asia
+        uses: hashicorp/packer-github-actions@master
+        if: matrix.cloud == 'gcp'
+        env:
+          PKR_VAR_image_storage_location: asia
+          PKR_VAR_zone: asia-northeast2-a
+        with:
+          command: build
+          target: gcp.pkr.hcl
+
+      - name: GCP => Add IAM policy binding to the Compute Engine images
+        if: matrix.cloud == 'gcp'
+        run: |
+          gcloud compute images add-iam-policy-binding ${PKR_VAR_image_base_name}-us-${PKR_VAR_suffix} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
+          gcloud compute images add-iam-policy-binding ${PKR_VAR_image_base_name}-eu-${PKR_VAR_suffix} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
+          gcloud compute images add-iam-policy-binding ${PKR_VAR_image_base_name}-asia-${PKR_VAR_suffix} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: Validate the Packer templates
+
+on:
+  push:
+    branches-ignore: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 👷 ${{ matrix.cloud }}
+    strategy:
+      matrix:
+        cloud: [aws, azure, gcp]
+    runs-on: ubuntu-latest
+    env:
+      # GCP
+      PKR_VAR_project_id: spacelift-workers
+      PKR_VAR_account_file: ./gcp.json
+      PKR_VAR_image_base_name: spacelift-worker
+      PKR_VAR_image_family: spacelift-worker
+      # Azure
+      PKR_VAR_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+      PKR_VAR_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      PKR_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      PKR_VAR_image_resource_group: rg-worker_images-public-westeurope
+      PKR_VAR_packer_work_group: rg-worker_images_packer-public-westeurope
+      PKR_VAR_gallery_resource_group: rg-worker_images-public-westeurope
+      PKR_VAR_gallery_name: worker_images_public
+      PKR_VAR_gallery_image_name: ubuntu_20_04
+      PKR_VAR_gallery_replication_regions: '["westeurope"]'
+      PKR_VAR_gallery_image_version: 1.0.${{ github.run_number }}
+
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@main
+
+      - name: Create account file for GCP
+        if: matrix.cloud == 'gcp'
+        run: |
+          echo '${{ secrets.GCP_CREDENTIALS_JSON }}' > ${{ env.PKR_VAR_account_file }}
+
+      - name: Export suffix for GCP
+        if: matrix.cloud == 'gcp'
+        run: |
+          echo "PKR_VAR_suffix=$(date +%s)-$(cat /dev/urandom | tr -dc 'a-z0-9' | head -c 8)" >> $GITHUB_ENV
+
+      - name: Validate the Packer template
+        uses: hashicorp/packer-github-actions@master
+        with:
+          command: validate
+          target: ${{ matrix.cloud }}.pkr.hcl


### PR DESCRIPTION
## Description of the change

Moving the building from CodeBuild to GitHub Actions. We have 3 actions

- `ci.yml` => for CI/CD, validating the templates
- `build_aws_scheduled.yml` => every Sunday automated AWS build
- `build_gcp_azure_manual.yml` => manual GCP and Azure build, which you need to start by clicking  a button

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
