### PR TITLE
Copy over env var from AWS CodeBuild to fix build

### DIFF
--- a/.github/workflows/build_aws_scheduled.yml
+++ b/.github/workflows/build_aws_scheduled.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Every Sunday at 23:00 UTC
     - cron: "00 23 * * 0"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,6 +13,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      PKR_VAR_encrypt_boot: false
     steps:
       - name: Check out the source code
         uses: actions/checkout@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
         cloud: [aws, azure, gcp]
     runs-on: ubuntu-latest
     env:
+      # AWS
+      PKR_VAR_encrypt_boot: false
       # GCP
       PKR_VAR_project_id: spacelift-workers
       PKR_VAR_account_file: ./gcp.json


### PR DESCRIPTION
## Description of the change

For some reason, we hid this env variable in the `Environment` settings of the CodeBuild project. 🤦 I didn't notice it.

This is why the build failed.

One other thing I added is the ability to manually kick the build.

```
==> amazon-ebs.spacelift: Error modify AMI attributes: UnsupportedOperation: Encrypted snapshots can't be shared publicly. Specify another snapshot.
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
