### PR TITLE
Remove eu-central-2 from AMI aws regions

### DIFF
--- a/aws.pkr.hcl
+++ b/aws.pkr.hcl
@@ -14,7 +14,6 @@ variable "ami_regions" {
     "ap-south-1",
     "ca-central-1",
     "eu-central-1",
-    "eu-central-2",
     "eu-west-1",
     "eu-west-2",
     "eu-west-3",


### PR DESCRIPTION
## Description of the change

Remove eu-central-2 from AMI aws regions

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
