### PR TITLE
Deprecate old AMIs (keep 180)

### DIFF
--- a/.github/workflows/build_aws_scheduled.yml
+++ b/.github/workflows/build_aws_scheduled.yml
@@ -33,23 +33,22 @@ jobs:
         uses: actions/checkout@main
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-duration-seconds: 3600
 
-      - name: Validate the Packer template
-        uses: hashicorp/packer-github-actions@master
+      - name: Setup packer
+        uses: hashicorp/setup-packer@main
         with:
-          command: validate
-          target: aws.pkr.hcl
+          version: latest
+
+      - name: Initialize Packer
+        run: packer init aws.pkr.hcl
 
       - name: Build the AWS AMI using Packer (${{ matrix.arch }})
-        uses: hashicorp/packer-github-actions@master
-        with:
-          command: build
-          target: aws.pkr.hcl
+        run: packer build aws.pkr.hcl
         env:
             PKR_VAR_encrypt_boot: false
             PKR_VAR_ami_name_prefix: spacelift-${{ needs.timestamp.outputs.timestamp }}
@@ -72,17 +71,22 @@ jobs:
         uses: actions/checkout@main
 
       - name: Configure GovCloud AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ secrets.GOVCLOUD_AWS_REGION }}
           role-to-assume: ${{ secrets.GOVCLOUD_AWS_ROLE_ARN }}
           role-duration-seconds: 3600
 
-      - name: Build the GovCloud AWS AMI using Packer (${{ matrix.arch }})
-        uses: hashicorp/packer-github-actions@master
+      - name: Setup packer
+        uses: hashicorp/setup-packer@main
         with:
-          command: build
-          target: aws.pkr.hcl
+          version: latest
+
+      - name: Initialize Packer
+        run: packer init aws.pkr.hcl
+
+      - name: Build the GovCloud AWS AMI using Packer (${{ matrix.arch }})
+        run: packer build aws.pkr.hcl
         env:
           PKR_VAR_source_ami_owners: '["045324592363"]'
           PKR_VAR_region: us-gov-east-1

--- a/.github/workflows/build_gcp_azure_manual.yml
+++ b/.github/workflows/build_gcp_azure_manual.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -63,48 +63,38 @@ jobs:
         run: |
           echo "PKR_VAR_suffix=$(date +%s)-$(cat /dev/urandom | tr -dc 'a-z0-9' | head -c 8)" >> $GITHUB_ENV
 
-      - name: Validate the Packer template
-        uses: hashicorp/packer-github-actions@master
+      - name: Setup packer
+        uses: hashicorp/setup-packer@main
         with:
-          command: validate
-          target: ${{ matrix.cloud }}.pkr.hcl
+          version: latest
+
+      - name: Initialize Packer
+        run: packer init ${{ matrix.cloud }}.pkr.hcl
 
       - name: Azure => Build the AMI using Packer
-        uses: hashicorp/packer-github-actions@master
         if: matrix.cloud == 'azure'
-        with:
-          command: build
-          target: azure.pkr.hcl
+        run: packer build azure.pkr.hcl
       
       - name: GCP => Build the AMI using Packer for US
-        uses: hashicorp/packer-github-actions@master
         if: matrix.cloud == 'gcp'
+        run: packer build gcp.pkr.hcl
         env:
           PKR_VAR_image_storage_location: us
           PKR_VAR_zone: us-central1-a
-        with:
-          command: build
-          target: gcp.pkr.hcl
 
       - name: GCP => Build the AMI using Packer for EU
-        uses: hashicorp/packer-github-actions@master
         if: matrix.cloud == 'gcp'
+        run: packer build gcp.pkr.hcl
         env:
           PKR_VAR_image_storage_location: eu
           PKR_VAR_zone: europe-west1-d
-        with:
-          command: build
-          target: gcp.pkr.hcl
 
       - name: GCP => Build the AMI using Packer for Asia
-        uses: hashicorp/packer-github-actions@master
         if: matrix.cloud == 'gcp'
+        run: packer build gcp.pkr.hcl
         env:
           PKR_VAR_image_storage_location: asia
           PKR_VAR_zone: asia-northeast2-a
-        with:
-          command: build
-          target: gcp.pkr.hcl
 
       - name: GCP => Add IAM policy binding to the Compute Engine images
         if: matrix.cloud == 'gcp'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,14 @@ jobs:
         run: |
           echo "PKR_VAR_suffix=$(date +%s)-$(cat /dev/urandom | tr -dc 'a-z0-9' | head -c 8)" >> $GITHUB_ENV
 
-      - name: Validate the Packer template
-        uses: hashicorp/packer-github-actions@master
+      - name: Setup packer
+        uses: hashicorp/setup-packer@main
         with:
-          command: validate
-          target: ${{ matrix.cloud }}.pkr.hcl
+          version: latest
+
+      - name: Initialize Packer
+        run: packer init ${{ matrix.cloud }}.pkr.hcl
+
+      - name: Validate the Packer template
+        id: validate
+        run: packer validate ${{ matrix.cloud }}.pkr.hcl


### PR DESCRIPTION
## Description of the change

Deprecate old AMIs and keep only 80.

Plus modernize the build process, we used an outdated package.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
