### PR TITLE
fix: amazon-ami-management plugin

### DIFF
--- a/aws.pkr.hcl
+++ b/aws.pkr.hcl
@@ -6,8 +6,8 @@ packer {
     }
 
     amazon-ami-management = {
-      version = "2.0.0"
-      source = "github.com/spacelift-io/amazon-ami-management"
+      version = "= 1.5.0"
+      source = "github.com/wata727/amazon-ami-management"
     }
   }
 }
@@ -161,8 +161,9 @@ build {
   post-processor "amazon-ami-management" {
     # Deregister old AMIs, keep only the latest 180.
     regions = var.ami_regions
-    tag_key = "Name"
-    tag_value = "Spacelift AMI"
+    tags = {
+      Name = "Spacelift AMI"
+    }
     keep_releases = 180
   }
 


### PR DESCRIPTION
## Description of the change

Recent versions of Packer have validation to ensure that the version of the plugin reported via the `describe` command match the version in the filename. Our fork of the `amazon-ami-management` plugin had its version set to `2.0.0-dev`, but the filename just had `2.0.0`.

The reason we had forked was to add the ability to filter by tags. This functionality is available in the upstream, which also has the fix for the version number, so we can switch back.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
