### PR TITLE
ci: switch to OIDC Federation for Azure

### DIFF
--- a/.github/workflows/build_gcp_azure_manual.yml
+++ b/.github/workflows/build_gcp_azure_manual.yml
@@ -20,10 +20,11 @@ jobs:
       PKR_VAR_image_base_name: spacelift-worker
       PKR_VAR_image_family: spacelift-worker
       # Azure
-      PKR_VAR_client_id: ${{ secrets.AZURE_CLIENT_ID }}
-      PKR_VAR_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      PKR_VAR_client_id: "976e4a6e-c619-417e-9add-50e2d674e2db"
       PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
       PKR_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      PKR_VAR_oidc_request_url: "${ACTIONS_ID_TOKEN_REQUEST_URL}"
+      PKR_VAR_oidc_request_token: "${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
       PKR_VAR_image_resource_group: rg-worker_images-public-westeurope
       PKR_VAR_packer_work_group: rg-worker_images_packer-public-westeurope
       PKR_VAR_gallery_resource_group: rg-worker_images-public-westeurope
@@ -74,7 +75,7 @@ jobs:
       - name: Azure => Build the AMI using Packer
         if: matrix.cloud == 'azure'
         run: packer build azure.pkr.hcl
-      
+
       - name: GCP => Build the AMI using Packer for US
         if: matrix.cloud == 'gcp'
         run: packer build gcp.pkr.hcl
@@ -152,9 +153,9 @@ jobs:
 
             content = fs.readFileSync("./manifest_gcp.json", "utf8");
             manifest = JSON.parse(content);
-            
+
             const gcpLinesToPrint = [];
-            
+
             manifest["builds"].forEach((build) => {
                 artifact = build["artifact_id"];
                 if (artifact.indexOf("-us-") > 0) {
@@ -167,7 +168,7 @@ jobs:
                     gcpLinesToPrint.push(` - Asia | \`${artifact}\``);
                 }
             });
-            
+
             console.log("## Azure");
             console.log("");
             console.log(`- Publisher | \`spaceliftinc1625499025476\`.`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         cloud: [aws, azure, gcp]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       # AWS
       PKR_VAR_encrypt_boot: false
@@ -24,10 +27,11 @@ jobs:
       PKR_VAR_image_base_name: spacelift-worker
       PKR_VAR_image_family: spacelift-worker
       # Azure
-      PKR_VAR_client_id: ${{ secrets.AZURE_CLIENT_ID }}
-      PKR_VAR_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      PKR_VAR_client_id: "433d3ca3-1866-4dfa-b9bf-65d6c4391ec7"
       PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
       PKR_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      PKR_VAR_oidc_request_url: "${ACTIONS_ID_TOKEN_REQUEST_URL}"
+      PKR_VAR_oidc_request_token: "${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
       PKR_VAR_image_resource_group: rg-worker_images-public-westeurope
       PKR_VAR_packer_work_group: rg-worker_images_packer-public-westeurope
       PKR_VAR_gallery_resource_group: rg-worker_images-public-westeurope

--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -12,7 +12,12 @@ variable "client_id" {
   default = ""
 }
 
-variable "client_secret" {
+variable "oidc_request_url" {
+  type    = string
+  default = ""
+}
+
+variable "oidc_request_token" {
   type    = string
   default = ""
 }
@@ -97,10 +102,11 @@ variable "packer_work_group" {
 }
 
 source "azure-arm" "spacelift" {
-  client_id       = var.client_id
-  client_secret   = var.client_secret
-  subscription_id = var.subscription_id
-  tenant_id       = var.tenant_id
+  client_id          = var.client_id
+  subscription_id    = var.subscription_id
+  tenant_id          = var.tenant_id
+  oidc_request_url   = var.oidc_request_url
+  oidc_request_token = var.oidc_request_token
 
   managed_image_name                = var.image_name
   managed_image_resource_group_name = var.image_resource_group


### PR DESCRIPTION
## Description of the change

Updating the packer build for Azure to use OIDC Federation instead of a static credential.

I've updated the CI build to have valid credentials for a service principal. This new SP has no access to anything - I've just added it to allow the packer validate step to work. I've also just hard-coded the client IDs into the actions on the grounds that they aren't credentials and don't need to be in secrets.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);
- [x] Other;

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
