### PR TITLE
Add OIDC permissions to Azure job

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -106,6 +106,9 @@ jobs:
   azure:
     name: Build Azure AMI using Packer
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       PKR_VAR_client_id: "976e4a6e-c619-417e-9add-50e2d674e2db"
       PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Description of the change

I'm suspecting that this error happened because GitHub didn't inject the OIDC credentials.

<img width="903" alt="image" src="https://github.com/user-attachments/assets/3601e0c6-a33c-46de-bfbb-e3d40f92f56b">


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
