### PR TITLE
Decrease size back to 8GB, remove debug statement

### DIFF
--- a/aws.pkr.hcl
+++ b/aws.pkr.hcl
@@ -104,7 +104,7 @@ source "amazon-ebs" "spacelift" {
 
   launch_block_device_mappings {
     device_name = "/dev/xvda"
-    volume_size = 14
+    volume_size = 8
     volume_type = "gp3"
     delete_on_termination = true
   }

--- a/aws/scripts/cloudwatch-agent.sh
+++ b/aws/scripts/cloudwatch-agent.sh
@@ -14,7 +14,6 @@ RPM_PATH=/tmp/amazon-cloudwatch-agent.rpm
 sudo touch /var/log/spacelift/{info,error}.log
 
 curl $DOWNLOAD_URL --output $RPM_PATH
-df # Temporarily, till we figure out the disk space issue
 sudo rpm -U $RPM_PATH
 rm $RPM_PATH
 sudo mv ${CONFIG_SOURCE} ${CONFIG_DESTINATION}


### PR DESCRIPTION
## Description of the change

We fixed the issue, but it wasn't the size bump that fixed it. So now decreasing it back to 8GB and removing the statement.

https://github.com/spacelift-io/spacelift-worker-image/actions/runs/11975118340/job/33387759381

<img width="815" alt="image" src="https://github.com/user-attachments/assets/fecb6283-62fa-45d6-8476-db1ce98bc067">


## Type of change

- [x] Other

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
