### PR TITLE
Fix cleanup race condition between AWS architectures

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -48,7 +48,8 @@ jobs:
         run: packer init aws.pkr.hcl
 
       - name: Build the AWS AMI using Packer (${{ matrix.arch }})
-        run: packer build aws.pkr.hcl
+        # We only run the cleanup postprocessor for one of them, to avoid race conditions
+        run: packer build aws.pkr.hcl ${{ matrix.arch == 'x86_64' && '--except=amazon-ami-management' || '' }}
         env:
           PKR_VAR_encrypt_boot: false
           PKR_VAR_ami_name_prefix: spacelift-${{ needs.timestamp.outputs.timestamp }}
@@ -93,7 +94,8 @@ jobs:
         run: packer init aws.pkr.hcl
 
       - name: Build the GovCloud AWS AMI using Packer (${{ matrix.arch }})
-        run: packer build aws.pkr.hcl
+        # We only run the cleanup postprocessor for one of them, to avoid race conditions
+        run: packer build aws.pkr.hcl ${{ matrix.arch == 'x86_64' && '--except=amazon-ami-management' || '' }}
         env:
           PKR_VAR_source_ami_owners: '["045324592363"]'
           PKR_VAR_region: us-gov-east-1


### PR DESCRIPTION
## Description of the change

This PR fixes the issue where both x64 and arm64 architectures are trying to deregister old AMIs at the same time. One of them ends up failing.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
