### PR TITLE
Clear Packer authorized key after build

### DIFF
--- a/aws.pkr.hcl
+++ b/aws.pkr.hcl
@@ -118,10 +118,11 @@ It contains all the neccessary tools to run Spacelift workers.
 More information: https://docs.spacelift.io.
 EOT
 
-  shared_credentials_file = var.shared_credentials_file
-  encrypt_boot            = var.encrypt_boot
-  instance_type           = var.instance_type
-  ssh_username            = "ec2-user"
+  shared_credentials_file   = var.shared_credentials_file
+  encrypt_boot              = var.encrypt_boot
+  instance_type             = var.instance_type
+  ssh_username              = "ec2-user"
+  ssh_clear_authorized_keys = true
 
   vpc_id = var.vpc_id
   region = var.region

--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -131,6 +131,8 @@ source "azure-arm" "spacelift" {
 
   vm_size  = var.vm_size
 
+  ssh_clear_authorized_keys = true
+
   azure_tags = merge(var.additional_tags, {
     Name                 = "Spacelift Worker Image"
     SourceImagePublisher = var.source_image_publisher

--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -63,14 +63,15 @@ variable "zone" {
 }
 
 source "googlecompute" "spacelift" {
-  project_id          = var.project_id
-  source_image_family = var.source_image_family
-  source_image        = var.source_image
-  ssh_username        = "spacelift"
-  zone                = var.zone
-  disk_size           = 50
-  machine_type        = var.machine_type
-  account_file        = var.account_file
+  project_id                = var.project_id
+  source_image_family       = var.source_image_family
+  source_image              = var.source_image
+  ssh_username              = "spacelift"
+  ssh_clear_authorized_keys = true
+  zone                      = var.zone
+  disk_size                 = 50
+  machine_type              = var.machine_type
+  account_file              = var.account_file
 
   image_name              = "${var.image_base_name}-${var.image_storage_location}-${var.suffix}"
   image_family            = var.image_family


### PR DESCRIPTION
## Description of the change

For: https://github.com/spacelift-io/spacelift-worker-image/issues/81

Note that this is a cosmetic option as Packer always deletes the temp keypair. [Docs](https://developer.hashicorp.com/packer/docs/communicators/ssh). (Regardless, I think deleting it should be the default. It's strange that it is not.)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
