### PR TITLE
chore: added systemctl enable amazon-cloudwatch-agent.service

### DIFF
--- a/aws/scripts/cloudwatch-agent.sh
+++ b/aws/scripts/cloudwatch-agent.sh
@@ -18,3 +18,4 @@ sudo rpm -U $RPM_PATH
 rm $RPM_PATH
 sudo mv ${CONFIG_SOURCE} ${CONFIG_DESTINATION}
 sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:${CONFIG_DESTINATION}
+sudo systemctl enable amazon-cloudwatch-agent.service


### PR DESCRIPTION
## Description of the change

As far as I can see `amazon-cloudwatch-agent` does not start automatically after VM start.
This one line of change should fix it.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [x] Changes have been reviewed by at least one other engineer;
