### PR TITLE
Rename manifest file before uploading

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -105,10 +105,14 @@ jobs:
           PKR_VAR_source_ami_architecture: ${{ matrix.arch }}
           PKR_VAR_instance_type: ${{ matrix.arch == 'x86_64' && 't3.micro' || 't4g.micro' }}
 
+      - name: Rename the manifest file
+        run: |
+          mv manifest_aws_${{ matrix.arch }}.json manifest_aws_govcloud_${{ matrix.arch }}.json
+
       - name: Upload manifest
         uses: actions/upload-artifact@v4
         with:
-          path: manifest_aws_${{ matrix.arch }}.json
+          path: manifest_aws_govcloud_${{ matrix.arch }}.json
           name: manifest_aws_govcloud_${{ matrix.arch }}.json
           retention-days: 5
 


### PR DESCRIPTION
## Description of the change

Apparently the previous solution didn't work, because `path` just specifies the archive's name, not the actual file name:

<img width="715" alt="image" src="https://github.com/user-attachments/assets/45789245-fe07-43be-8f19-97753505ae42" />

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
