### PR TITLE
fix: pass GitHub token to packer init

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Initialize Packer
         run: packer init aws.pkr.hcl
+        env:
+          PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
 
       - name: Build the AWS AMI using Packer (${{ matrix.arch }})
         # We only run the cleanup postprocessor for one of them, to avoid race conditions
@@ -92,6 +94,8 @@ jobs:
 
       - name: Initialize Packer
         run: packer init aws.pkr.hcl
+        env:
+          PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
 
       - name: Build the GovCloud AWS AMI using Packer (${{ matrix.arch }})
         # We only run the cleanup postprocessor for one of them, to avoid race conditions
@@ -145,6 +149,8 @@ jobs:
 
       - name: Initialize Packer
         run: packer init azure.pkr.hcl
+        env:
+          PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
 
       - name: Azure => Build the AMI using Packer
         run: packer build azure.pkr.hcl
@@ -203,6 +209,8 @@ jobs:
 
       - name: Initialize Packer
         run: packer init gcp.pkr.hcl
+        env:
+          PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
 
       - name: GCP => Build the AMI using Packer for US
         run: packer build gcp.pkr.hcl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Initialize Packer
         run: packer init ${{ matrix.cloud }}.pkr.hcl
+        env:
+          PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
 
       - name: Validate the Packer template
         id: validate


### PR DESCRIPTION
## Description of the change

We're hitting rate limits when running `packer init`. Authenticated requests get higher rate limits, so I'm passing the GitHub token to packer to try to solve this.

This is an attempt at fixing [this issue](https://github.com/spacelift-io/spacelift-worker-image/actions/runs/14023871811/job/39276124991):

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/a4fbb8ae-97c2-464b-a176-cca671b7d805" />

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
