### PR TITLE
Add `eu-central-2` to AWS regions

### DIFF
--- a/aws.pkr.hcl
+++ b/aws.pkr.hcl
@@ -28,6 +28,7 @@ variable "ami_regions" {
     "ap-south-1",
     "ca-central-1",
     "eu-central-1",
+    "eu-central-2",
     "eu-west-1",
     "eu-west-2",
     "eu-west-3",


### PR DESCRIPTION
## Description of the change

A customer of ours requested a new region for the worker images: https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/pull/106#issuecomment-2858055042

I enabled the region in the account. Should take a few minutes/hours to propagate.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
