### PR TITLE
Bump GCP base image to Ubuntu 24 LTS

### DIFF
--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -34,12 +34,7 @@ variable "image_storage_location" {
 
 variable "source_image_family" {
   type    = string
-  default = "ubuntu-2004-lts"
-}
-
-variable "source_image" {
-  type    = string
-  default = null
+  default = "ubuntu-2404-lts-amd64"
 }
 
 variable "suffix" {
@@ -65,7 +60,6 @@ variable "zone" {
 source "googlecompute" "spacelift" {
   project_id                = var.project_id
   source_image_family       = var.source_image_family
-  source_image              = var.source_image
   ssh_username              = "spacelift"
   ssh_clear_authorized_keys = true
   zone                      = var.zone


### PR DESCRIPTION

## Description of the change

Apparently Ubuntu 20.04 is deprecated:

<img width="883" alt="image" src="https://github.com/user-attachments/assets/1dd72b40-94b1-41a5-8cd4-772df8662f29" />

From: https://cloud.google.com/compute/docs/images/os-details#ubuntu_lts

Failing build: https://github.com/spacelift-io/spacelift-worker-image/actions/runs/15668299033/job/44135335302

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
