### PR TITLE
GCP: switch deprecated parameter

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -178,7 +178,7 @@ jobs:
       contents: read
     env:
       PKR_VAR_project_id: spacelift-workers
-      PKR_VAR_account_file: ./gcp.json
+      PKR_VAR_credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
       PKR_VAR_image_base_name: spacelift-worker
       PKR_VAR_image_family: spacelift-worker
 
@@ -188,10 +188,6 @@ jobs:
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
-
-      - name: Create account file for GCP
-        run: |
-          echo '${{ secrets.GCP_CREDENTIALS_JSON }}' > ${{ env.PKR_VAR_account_file }}
 
       - name: Authenticate with GCP
         uses: google-github-actions/auth@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       PKR_VAR_encrypt_boot: false
       # GCP
       PKR_VAR_project_id: spacelift-workers
-      PKR_VAR_account_file: ./gcp.json
+      PKR_VAR_credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
       PKR_VAR_image_base_name: spacelift-worker
       PKR_VAR_image_family: spacelift-worker
       # Azure
@@ -41,11 +41,6 @@ jobs:
     steps:
       - name: Check out the source code
         uses: actions/checkout@main
-
-      - name: Create account file for GCP
-        if: matrix.cloud == 'gcp'
-        run: |
-          echo '${{ secrets.GCP_CREDENTIALS_JSON }}' > ${{ env.PKR_VAR_account_file }}
 
       - name: Export suffix for GCP
         if: matrix.cloud == 'gcp'

--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -7,7 +7,7 @@ packer {
   }
 }
 
-variable "account_file" {
+variable "credentials_json" {
   type    = string
   default = null
 }
@@ -65,7 +65,7 @@ source "googlecompute" "spacelift" {
   zone                      = var.zone
   disk_size                 = 50
   machine_type              = var.machine_type
-  account_file              = var.account_file
+  credentials_json          = var.credentials_json
 
   image_name              = "${var.image_base_name}-${var.image_storage_location}-${var.suffix}"
   image_family            = var.image_family


### PR DESCRIPTION
## Description of the change

Noticed this warning in [the most recent build](https://github.com/spacelift-io/spacelift-worker-image/actions/runs/15680209558/job/44169625619):

<img width="1054" alt="image" src="https://github.com/user-attachments/assets/71203de4-596f-41d9-a91a-91448d95806f" />


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
