### PR TITLE
fix: casing of Azure image gallery ID in release notes

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -421,7 +421,7 @@ jobs:
                 "- Community Gallery Name | `spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079`",
                 "- Image name | `spacelift_worker_image_ubu_lts`",
                 `- Version | \`${process.env.AZURE_VERSION}\``,
-                `- Resource ID | \`/CommunityGalleries/spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079/Images/spacelift_worker_image_ubu_lts/Versions/${process.env.AZURE_VERSION}\``,
+                `- Resource ID | \`/communityGalleries/spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079/images/spacelift_worker_image_ubu_lts/versions/${process.env.AZURE_VERSION}\``,
                 "",
                 "## Google Cloud Platform",
                 "",


### PR DESCRIPTION
## Description of the change

The release notes are using the wrong casing for some of the path parts of the Azure community image gallery ID. This causes it to fail validation if you attempt to use it with OpenTofu / Terraform.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [x] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
