### PR TITLE
Remove kmod upgrade CVE-2026-31431 mitigation

### DIFF
--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -152,8 +152,7 @@ build {
       "shared/scripts/apt-install-docker.sh",
       "shared/scripts/gvisor.sh",
       "shared/scripts/apt-install-jq.sh",
-      "azure/scripts/azure-cli.sh",
-      "azure/scripts/kmod-upgrade.sh"
+      "azure/scripts/azure-cli.sh"
     ]
 
     env = {

--- a/azure/scripts/kmod-upgrade.sh
+++ b/azure/scripts/kmod-upgrade.sh
@@ -1,5 +1,0 @@
-# Mitigates CVE-2026-31431 (Copy Fail) - upgrades kmod to a version that blocks
-# the algif_aead kernel module, which enables local privilege escalation to root.
-# More: https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available
-
-sudo apt-get update && sudo apt-get install -y --only-upgrade kmod


### PR DESCRIPTION
## Description of the change

The Azure base image now ships a patched kmod, so the manual upgrade is a no-op and no longer needed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
