### PR TITLE
feat: validate AMI on a worker pool before publishing

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -22,48 +22,21 @@ jobs:
     needs: timestamp
     strategy:
       matrix:
-        arch: [x86_64, arm64]
-    name: Build the AWS AMI using Packer
-    runs-on: ubuntu-latest
+        include:
+          - arch: x86_64
+            instance_type: t3.micro
+          - arch: arm64
+            instance_type: t4g.micro
+    name: Build/test/publish AWS AMI (${{ matrix.arch }})
     permissions:
       id-token: write
       contents: read
-    steps:
-      - name: Check out the source code
-        uses: actions/checkout@main
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 3600
-
-      - name: Setup packer
-        uses: hashicorp/setup-packer@main
-        with:
-          version: latest
-
-      - name: Initialize Packer
-        run: packer init aws.pkr.hcl
-        env:
-          PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
-
-      - name: Build the AWS AMI using Packer (${{ matrix.arch }})
-        # We only run the cleanup postprocessor for one of them, to avoid race conditions
-        run: packer build ${{ matrix.arch == 'x86_64' && '--except=amazon-ami-management' || '' }} aws.pkr.hcl
-        env:
-          PKR_VAR_encrypt_boot: false
-          PKR_VAR_ami_name_prefix: spacelift-${{ needs.timestamp.outputs.timestamp }}
-          PKR_VAR_source_ami_architecture: ${{ matrix.arch }}
-          PKR_VAR_instance_type: ${{ matrix.arch == 'x86_64' && 't3.micro' || 't4g.micro' }}
-
-      - name: Upload manifest
-        uses: actions/upload-artifact@v7
-        with:
-          path: manifest_aws_${{ matrix.arch }}.json
-          name: manifest_aws_${{ matrix.arch }}.json
-          retention-days: 5
+    uses: ./.github/workflows/job_build_publish-aws.yml
+    secrets: inherit
+    with:
+      arch: ${{ matrix.arch }}
+      instance_type: ${{ matrix.instance_type }}
+      timestamp: ${{ needs.timestamp.outputs.timestamp }}
 
   aws-govcloud:
     # Since we run in parallel, let's make sure we use the same timestamp for all jobs

--- a/.github/workflows/job_build_publish-aws.yml
+++ b/.github/workflows/job_build_publish-aws.yml
@@ -106,6 +106,7 @@ jobs:
 
       - name: Resolve the pool's ASG name
         id: asg
+        shell: bash
         run: |
           set -euo pipefail
           # `.value` is double-encoded (a JSON string containing quotes), so fromjson decodes it.
@@ -121,6 +122,29 @@ jobs:
           aws-region: ${{ env.TEST_REGION }}
           role-to-assume: ${{ vars.PRIVATE_WORKER_POOL_AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 3600
+
+      - name: Verify the ASG launch template is on the new AMI
+        # Sanity check before cycling: resolve the exact launch-template version the
+        # ASG references and confirm its ImageId is the AMI we just built, so we know
+        # the instance refresh will actually test the new image and not an old one.
+        env:
+          ASG_NAME: ${{ steps.asg.outputs.asg_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          
+          lt=$(aws autoscaling describe-auto-scaling-groups \
+            --auto-scaling-group-names "$ASG_NAME" \
+            --query 'AutoScalingGroups[0].LaunchTemplate.[LaunchTemplateId,Version]' --output text)
+          lt_id=$(printf '%s' "$lt" | cut -f1)
+          lt_ver=$(printf '%s' "$lt" | cut -f2)
+          
+          lt_ami=$(aws ec2 describe-launch-template-versions \
+            --launch-template-id "$lt_id" --versions "$lt_ver" \
+            --query 'LaunchTemplateVersions[0].LaunchTemplateData.ImageId' --output text)
+          
+          echo "LT $lt_id v$lt_ver -> $lt_ami (expected $NEW_AMI)"
+          [ "$lt_ami" = "$NEW_AMI" ] || { echo "ASG launch template is NOT on the new AMI" >&2; exit 1; }
 
       - name: Cycle the worker onto the new AMI (ASG instance refresh)
         uses: spacelift-io/public-shared-actions/actions/refresh-workerpool-asg@main

--- a/.github/workflows/job_build_publish-aws.yml
+++ b/.github/workflows/job_build_publish-aws.yml
@@ -1,0 +1,171 @@
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: "Source AMI architecture (x86_64 or arm64)."
+        type: string
+        required: true
+      instance_type:
+        description: "EC2 instance type used to build this arch's AMI."
+        type: string
+        required: true
+      timestamp:
+        description: "Unified build timestamp; drives the spacelift-<timestamp> AMI name."
+        type: string
+        required: true
+
+name: Build, test and publish AWS AMI
+
+env:
+  TEST_REGION: eu-west-1
+  TEST_AWS_ACCOUNT_ID: ${{ vars.TEST_AWS_ACCOUNT_ID }}
+  SPACELIFT_API_KEY_ENDPOINT: https://spacelift-ci-gh.app.spacelift.dev
+  WORKERPOOL_STACK: ami-build-resilience-workerpool
+  TEST_STACK: ami-resilience-testing
+
+jobs:
+  build:
+    name: Build private AMI (${{ inputs.arch }}, all regions)
+    runs-on: ubuntu-latest
+    env:
+      ARCH: ${{ inputs.arch }}
+    outputs:
+      test_ami: ${{ steps.extract.outputs.test_ami }}
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@main
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 3600
+
+      - name: Setup packer
+        uses: hashicorp/setup-packer@main
+        with:
+          version: latest
+
+      - name: Initialize Packer
+        run: packer init aws.pkr.hcl
+        env:
+          PACKER_GITHUB_API_TOKEN: ${{ github.token }}
+
+      - name: Build the AMI (PRIVATE)
+        # Run the amazon-ami-management cleanup post-processor for exactly one arch
+        # (skip it on x86_64) so the two matrix legs don't race on AMI deregistration.
+        run: packer build ${{ inputs.arch == 'x86_64' && '--except=amazon-ami-management' || '' }} aws.pkr.hcl
+        env:
+          PKR_VAR_encrypt_boot: false
+          PKR_VAR_ami_name_prefix: spacelift-${{ inputs.timestamp }}
+          PKR_VAR_source_ami_architecture: ${{ inputs.arch }}
+          PKR_VAR_instance_type: ${{ inputs.instance_type }}
+          # Build PRIVATE (ami_groups=[]); the publish job makes it public only after the test passes.
+          PKR_VAR_ami_groups: "[]"
+          PKR_VAR_ami_users: '["${{ env.TEST_AWS_ACCOUNT_ID }}"]'
+
+      - name: Extract the test-region AMI id
+        id: extract
+        run: |
+          set -euo pipefail
+          ami=$(jq -r '.builds[-1].artifact_id' "manifest_aws_${ARCH}.json" \
+            | tr ',' '\n' | grep "^${TEST_REGION}:" | cut -d: -f2)
+          [ -n "$ami" ] || { echo "no AMI for ${TEST_REGION} in manifest" >&2; exit 1; }
+          echo "test_ami=$ami" >> "$GITHUB_OUTPUT"
+          echo "Built ${TEST_REGION} AMI: $ami"
+
+      - name: Upload manifest
+        uses: actions/upload-artifact@v7
+        with:
+          name: manifest_aws_${{ inputs.arch }}.json
+          path: manifest_aws_${{ inputs.arch }}.json
+          retention-days: 5
+
+  test:
+    name: Deploy pool onto new AMI and run the test stack
+    needs: build
+    # The test pool is x86_64 (t3.small); an arm64 AMI can't launch on it. arm64
+    # builds and publishes without the on-pool test for now.
+    if: ${{ inputs.arch == 'x86_64' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      NEW_AMI: ${{ needs.build.outputs.test_ami }}
+    steps:
+      - name: Setup spacectl
+        uses: spacelift-io/setup-spacectl@main
+
+      - name: Point the workerpool stack at the new AMI
+        run: spacectl stack environment setvar --id "$WORKERPOOL_STACK" TF_VAR_ami_id "$NEW_AMI"
+
+      - name: Apply the workerpool stack (updates the launch template)
+        run: spacectl stack deploy --id "$WORKERPOOL_STACK" --auto-confirm
+
+      - name: Resolve the pool's ASG name
+        id: asg
+        run: |
+          set -euo pipefail
+          # `.value` is double-encoded (a JSON string containing quotes), so fromjson decodes it.
+          asg=$(spacectl stack outputs --id "$WORKERPOOL_STACK" --output json \
+            | jq -r '.[] | select(.id=="asg_name") | .value | fromjson')
+          [ -n "$asg" ] || { echo "asg_name output not found" >&2; exit 1; }
+          echo "asg_name=$asg" >> "$GITHUB_OUTPUT"
+          echo "ASG: $asg"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ env.TEST_REGION }}
+          role-to-assume: ${{ vars.PRIVATE_WORKER_POOL_AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 3600
+
+      - name: Cycle the worker onto the new AMI (ASG instance refresh)
+        uses: spacelift-io/public-shared-actions/actions/refresh-workerpool-asg@main
+        with:
+          asg_name: ${{ steps.asg.outputs.asg_name }}
+          aws_region: ${{ env.TEST_REGION }}
+          min_healthy_percentage: 0
+          instance_warmup_seconds: 0
+
+      - name: Run the test stack
+        run: spacectl stack deploy --id "$TEST_STACK" --auto-confirm
+
+  publish:
+    name: Publish in all regions
+    needs: [build, test]
+    # Publish once the build succeeded and the test either passed or was skipped
+    # (arm64 skips the x86_64-only pool test). Do NOT publish if the test failed.
+    if: ${{ always() && needs.build.result == 'success' && (needs.test.result == 'success' || needs.test.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    env:
+      ARCH: ${{ inputs.arch }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 3600
+
+      - name: Download manifest
+        uses: actions/download-artifact@v8
+        with:
+          name: manifest_aws_${{ env.ARCH }}.json
+
+      - name: Make each region's AMI public
+        run: |
+          set -euo pipefail
+          # Make the AMI public and, in the same call, drop the now-redundant explicit
+          # share to the testing account (added at build time via ami_users). Once the
+          # image is public the grant does nothing — this is hygiene, so a customer-facing
+          # public AMI carries no stray internal-account launch permission.
+          for pair in $(jq -r '.builds[-1].artifact_id' "manifest_aws_${ARCH}.json" | tr ',' '\n'); do
+            region="${pair%%:*}"
+            ami="${pair##*:}"
+            echo "Publishing $ami in $region"
+            aws ec2 modify-image-attribute --region "$region" --image-id "$ami" \
+              --launch-permission "Add=[{Group=all}],Remove=[{UserId=${TEST_AWS_ACCOUNT_ID}}]"
+          done

--- a/aws.pkr.hcl
+++ b/aws.pkr.hcl
@@ -7,7 +7,7 @@ packer {
 
     amazon-ami-management = {
       version = "= 1.6.1"
-      source = "github.com/wata727/amazon-ami-management"
+      source  = "github.com/wata727/amazon-ami-management"
     }
   }
 }
@@ -42,7 +42,7 @@ variable "ami_regions" {
 }
 
 variable "source_ami_architecture" {
-  type = string
+  type    = string
   default = "x86_64"
 }
 
@@ -54,6 +54,12 @@ variable "source_ami_owners" {
 variable "ami_groups" {
   type    = list(string)
   default = ["all"]
+}
+
+variable "ami_users" {
+  type        = list(string)
+  description = "AWS account IDs to share the (private) AMI with as an explicit launch permission."
+  default     = []
 }
 
 variable "instance_type" {
@@ -93,26 +99,27 @@ variable "vpc_id" {
 
 source "amazon-ebs" "spacelift" {
   source_ami_filter {
-      filters = {
-        virtualization-type = "hvm"
-        name                = "al2023-ami-minimal-*-kernel-6.1-${var.source_ami_architecture}"
-        root-device-type    = "ebs"
-        architecture        = var.source_ami_architecture
-      }
-      owners      = var.source_ami_owners
-      most_recent = true
+    filters = {
+      virtualization-type = "hvm"
+      name                = "al2023-ami-minimal-*-kernel-6.1-${var.source_ami_architecture}"
+      root-device-type    = "ebs"
+      architecture        = var.source_ami_architecture
+    }
+    owners      = var.source_ami_owners
+    most_recent = true
   }
 
   launch_block_device_mappings {
-    device_name = "/dev/xvda"
-    volume_size = 8
-    volume_type = "gp3"
+    device_name           = "/dev/xvda"
+    volume_size           = 8
+    volume_type           = "gp3"
     delete_on_termination = true
   }
 
-  ami_name    = "${var.ami_name_prefix}-${var.source_ami_architecture}"
-  ami_regions = var.ami_regions
-  ami_groups  = var.ami_groups
+  ami_name        = "${var.ami_name_prefix}-${var.source_ami_architecture}"
+  ami_regions     = var.ami_regions
+  ami_groups      = var.ami_groups
+  ami_users       = var.ami_users
   ami_description = <<EOT
 Spacelift AMI built for ${var.source_ami_architecture}-based private worker pools.
 It contains all the neccessary tools to run Spacelift workers.

--- a/infra/modules/github-deployment-role/main.tf
+++ b/infra/modules/github-deployment-role/main.tf
@@ -1,0 +1,47 @@
+# GitHub Actions OIDC deployment role.
+#
+# Lets GitHub Actions workflows in the given spacelift-io repository assume an
+# IAM role in this account via the GitHub OIDC provider, restricted to the
+# given git refs.
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_role" "this" {
+  name        = var.role_name
+  description = "Role for GitHub Actions deployments from spacelift-io/${var.repository}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = data.aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = [for ref in var.refs : "repo:spacelift-io/${var.repository}:${ref}"]
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "this" {
+  name        = "${var.role_name}-policy"
+  description = "Policy for ${var.role_name}"
+
+  policy = var.policy_document
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.this.arn
+}

--- a/infra/modules/github-deployment-role/outputs.tf
+++ b/infra/modules/github-deployment-role/outputs.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  description = "ARN of the deployment role"
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the deployment role"
+  value       = aws_iam_role.this.name
+}

--- a/infra/modules/github-deployment-role/variables.tf
+++ b/infra/modules/github-deployment-role/variables.tf
@@ -1,0 +1,19 @@
+variable "role_name" {
+  type        = string
+  description = "Name of the IAM role (must be unique in the account)"
+}
+
+variable "repository" {
+  type        = string
+  description = "spacelift-io repository allowed to assume the role"
+}
+
+variable "refs" {
+  type        = list(string)
+  description = "Git references allowed to assume the role, e.g. ref:refs/heads/main"
+}
+
+variable "policy_document" {
+  type        = string
+  description = "JSON policy document granting the role's permissions"
+}

--- a/infra/modules/github-deployment-role/versions.tf
+++ b/infra/modules/github-deployment-role/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/infra/stacks/workerpool-aws/data.tf
+++ b/infra/stacks/workerpool-aws/data.tf
@@ -1,0 +1,16 @@
+# Networking: default VPC in the AMI-owner account (643313122712), eu-west-1.
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_security_group" "default" {
+  vpc_id = data.aws_vpc.default.id
+  name   = "default"
+}

--- a/infra/stacks/workerpool-aws/github-deployment.tf
+++ b/infra/stacks/workerpool-aws/github-deployment.tf
@@ -15,8 +15,12 @@ module "github-deployment" {
         Resource = [module.workerpool.autoscaling_group_arn]
       },
       {
-        Effect   = "Allow"
-        Action   = ["autoscaling:DescribeInstanceRefreshes", "autoscaling:DescribeAutoScalingGroups"]
+        Effect = "Allow"
+        Action = [
+          "autoscaling:DescribeInstanceRefreshes",
+          "autoscaling:DescribeAutoScalingGroups",
+          "ec2:DescribeLaunchTemplateVersions",
+        ]
         Resource = "*"
       },
     ]

--- a/infra/stacks/workerpool-aws/github-deployment.tf
+++ b/infra/stacks/workerpool-aws/github-deployment.tf
@@ -1,0 +1,24 @@
+module "github-deployment" {
+  source = "../../modules/github-deployment-role"
+
+  role_name  = "github-deployment-spacelift-worker-image-workerpool"
+  repository = "spacelift-worker-image"
+
+  refs = ["ref:refs/heads/main", "pull_request", "ref:refs/heads/wojciechp/*"]
+
+  policy_document = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["autoscaling:StartInstanceRefresh"]
+        Resource = [module.workerpool.autoscaling_group_arn]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["autoscaling:DescribeInstanceRefreshes", "autoscaling:DescribeAutoScalingGroups"]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/infra/stacks/workerpool-aws/main.tf
+++ b/infra/stacks/workerpool-aws/main.tf
@@ -1,6 +1,6 @@
 resource "spacelift_worker_pool" "this" {
   name        = "ami-build-resilience-workerpool"
-  description = "EC2 pool for AMI validation (ami-resilience). Autoscaler disabled."
+  description = "EC2 pool for validating Spacelift Worker AMIs before they are published, driven by https://github.com/spacelift-io/spacelift-worker-image (ami-resilience). Autoscaler disabled."
   space_id    = "root" # else the API defaults the pool to the "legacy" space, invisible to a root stack
 }
 

--- a/infra/stacks/workerpool-aws/main.tf
+++ b/infra/stacks/workerpool-aws/main.tf
@@ -1,0 +1,28 @@
+resource "spacelift_worker_pool" "this" {
+  name        = "ami-build-resilience-workerpool"
+  description = "EC2 pool for AMI validation (ami-resilience). Autoscaler disabled."
+  space_id    = "root" # else the API defaults the pool to the "legacy" space, invisible to a root stack
+}
+
+module "workerpool" {
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v7.2.0"
+
+  binaries_download_base_url = "https://downloads.spacelift.dev"
+  base_name                  = "ci-workerpool-aws"
+  worker_pool_id             = spacelift_worker_pool.this.id
+  ec2_instance_type          = "t3.small"
+  ami_id                     = var.ami_id
+  min_size                   = 1
+  max_size                   = 2
+  vpc_subnets                = data.aws_subnets.default.ids
+  security_groups            = [data.aws_security_group.default.id]
+
+  manage_log_groups = false
+
+  env_vars = {
+    SPACELIFT_TOKEN                 = { value = spacelift_worker_pool.this.config, sensitive = true }
+    SPACELIFT_POOL_PRIVATE_KEY      = { value = spacelift_worker_pool.this.private_key, sensitive = true }
+    SPACELIFT_WORKER_COMMS_URL      = { value = "https://app.spacelift.dev" }
+    SPACELIFT_WORKER_COMMS_PROTOCOL = { value = "poll" }
+  }
+}

--- a/infra/stacks/workerpool-aws/outputs.tf
+++ b/infra/stacks/workerpool-aws/outputs.tf
@@ -1,0 +1,13 @@
+output "worker_pool_id" {
+  value = spacelift_worker_pool.this.id
+}
+
+output "asg_name" {
+  value = module.workerpool.autoscaling_group_name
+}
+
+# ARN of the GitHub Actions OIDC role for the ASG-refresh (cycle) step.
+# Set as the repo secret PRIVATE_WORKER_POOL_AWS_ROLE_TO_ASSUME.
+output "cycle_role_arn" {
+  value = module.github-deployment.role_arn
+}

--- a/infra/stacks/workerpool-aws/providers.tf
+++ b/infra/stacks/workerpool-aws/providers.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    spacelift = {
+      source  = "spacelift-io/spacelift"
+      version = "~> 1.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40.0"
+    }
+  }
+}
+
+# In-Spacelift runs use the auto-injected SPACELIFT_API_TOKEN, so no explicit
+# credentials are needed here. The stack's role must allow managing worker pools.
+provider "spacelift" {}
+
+# eu-west-1: the private AMI under test is a regional resource in its owner account.
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/infra/stacks/workerpool-aws/variables.tf
+++ b/infra/stacks/workerpool-aws/variables.tf
@@ -1,0 +1,4 @@
+variable "ami_id" {
+  type        = string
+  description = "AMI to launch workers from. Injected at run time via TF_VAR_ami_id; never committed."
+}


### PR DESCRIPTION

### Description of the change

Adds a validation gate before public AMIs ship. A new reusable workflow (job_build_publish-aws.yml) builds the AMI private, validates it on a real worker pool, then publishes it public per region — replacing the AWS build job in build_scheduled.yml.

Per arch:
1. Build private (ami_groups=[]), shared with the testing account via ami_users.
2. Test (x86_64 only): point the ami-build-resilience-workerpool stack at the new AMI, cycle its ASG, and run a real stack on it.
3. Publish: make public in all regions and drop the testing-account share. Runs only if the test passed (or was skipped for arm64).

build_scheduled.yml now calls this as a matrix (x86_64/arm64) with secrets: inherit. GovCloud, Azure, GCP, and the release job are unchanged.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
