### PR TITLE
fix(workerpool-aws): terraform init cannot resolve aws provider

### DIFF
--- a/infra/stacks/workerpool-aws/providers.tf
+++ b/infra/stacks/workerpool-aws/providers.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.40.0"
+      version = "~> 6.40"
     }
   }
 }


### PR DESCRIPTION
## Description of the change

`terraform init` for the `workerpool-aws` stack can no longer resolve the AWS provider on a fresh run. 
The autoscaling submodule (`terraform-aws-modules/autoscaling/aws` v9.3.0, pulled transitively) raised its
floor to `aws >= 6.56.0`, which the stack's `~> 6.40.0` pin (`>= 6.40.0, < 6.41.0`) excludes — so there is
no version satisfying both constraints and init fails. Widened the pin to `~> 6.40` (`>= 6.40, < 7.0`) so a
compatible 6.56+ release is selected while staying on the 6.x major.

```shell
- Installed hashicorp/external v2.4.0 (signed, key ID 0C0AF313E5FD9F80)
- Installed spacelift-io/spacelift v1.53.5 (signed, key ID E302FB5AA29D88F7)
╷
│ Error: Failed to resolve provider packages
│ 
│ Could not resolve provider hashicorp/aws: no available releases match the
│ given constraints >= 6.0.0, ~> 6.40.0, >= 6.56.0
╵

[01KZ689J15NCPSTCF8PZ7KQTH6] Unexpected exit code when initializing workspace: 1
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable; (n/a — provider constraint only)
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected; (n/a — no AMI/infra change)

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
