### PR TITLE
TEST: validate GovCloud build+test job

### DIFF
--- a/.github/workflows/test-workflow-govcloud.yml
+++ b/.github/workflows/test-workflow-govcloud.yml
@@ -90,12 +90,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
-      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
-      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      # OIDC-based API key. The var holds the full `oidc::<host>::<key-id>` value.
+      SPACELIFT_API_KEY_ID: ${{ vars.SPACELIFT_OIDC_API_KEY_ID }}
       NEW_AMI: ${{ needs.build.outputs.test_ami }}
     steps:
       - name: Setup spacectl
         uses: spacelift-io/setup-spacectl@main
+
+      - name: Authenticate to Spacelift via OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+          
+          SPACELIFT_API_KEY_SECRET=$(curl -sf \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=spacelift-ci-gh.app.spacelift.dev" | jq -r '.value')
+          export SPACELIFT_API_KEY_SECRET
+          token=$(spacectl profile export-token)
+          echo "::add-mask::$token"
+          echo "SPACELIFT_API_TOKEN=$token" >> "$GITHUB_ENV"
 
       - name: Point the workerpool stack at the new AMI
         run: spacectl stack environment setvar --id "$WORKERPOOL_STACK" TF_VAR_ami_id "$NEW_AMI"

--- a/.github/workflows/test-workflow-govcloud.yml
+++ b/.github/workflows/test-workflow-govcloud.yml
@@ -1,0 +1,154 @@
+name: TEST — build & validate GovCloud AMI (x86_64, us-gov-west-1)
+
+# Temporary PR-triggered workflow to validate the GovCloud build + test path (incl.
+# the launch-template sanity check) end to end. Copy of job_build_publish-aws-govcloud.yml
+# with ONLY the build and test jobs — no publish. Builds a PRIVATE, single-region
+# (us-gov-west-1), x86_64 AMI shared to the gov test account; never made public.
+# Remove before merge.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - wojciechp/test-ami-gov
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  ARCH: x86_64
+  TEST_REGION: us-gov-west-1
+  TEST_AWS_ACCOUNT_ID: "259242304461"
+  SPACELIFT_API_KEY_ENDPOINT: https://spacelift-ci-gh.app.spacelift.dev
+  WORKERPOOL_STACK: ami-build-resilience-workerpool-aws-gov
+  TEST_STACK: ami-resilience-testing-gov-aws
+
+jobs:
+  build:
+    name: Build private GovCloud AMI (x86_64, us-gov-west-1 only)
+    runs-on: ubuntu-latest
+    outputs:
+      test_ami: ${{ steps.extract.outputs.test_ami }}
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@main
+
+      - name: Configure GovCloud AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ secrets.GOVCLOUD_AWS_REGION }}
+          role-to-assume: ${{ secrets.GOVCLOUD_AWS_ROLE_ARN }}
+          role-duration-seconds: 3600
+
+      - name: Setup packer
+        uses: hashicorp/setup-packer@main
+        with:
+          version: latest
+
+      - name: Initialize Packer
+        run: packer init aws.pkr.hcl
+        env:
+          PACKER_GITHUB_API_TOKEN: ${{ github.token }}
+
+      - name: Unified build timestamp
+        id: ts
+        shell: bash
+        run: echo "ts=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Build the GovCloud AMI (PRIVATE, us-gov-west-1 only)
+        run: packer build --except=amazon-ami-management aws.pkr.hcl
+        env:
+          PKR_VAR_encrypt_boot: false
+          # "test-" prefix keeps these throwaway PR AMIs out of the customer-facing name
+          # filter. They stay private (never published) and must be deregistered manually.
+          PKR_VAR_ami_name_prefix: test-spacelift-${{ steps.ts.outputs.ts }}
+          PKR_VAR_source_ami_owners: '["045324592363"]'
+          PKR_VAR_source_ami_architecture: ${{ env.ARCH }}
+          PKR_VAR_instance_type: t3.micro
+          # Build PRIVATE and share with the gov test account so the pool can launch it.
+          PKR_VAR_ami_groups: "[]"
+          PKR_VAR_ami_users: '["${{ env.TEST_AWS_ACCOUNT_ID }}"]'
+          # Single region only — this workflow validates build + test, it never publishes.
+          PKR_VAR_region: ${{ env.TEST_REGION }}
+          PKR_VAR_ami_regions: '["${{ env.TEST_REGION }}"]'
+
+      - name: Extract the test-region AMI id
+        id: extract
+        shell: bash
+        run: |
+          set -euo pipefail
+          ami=$(jq -r '.builds[-1].artifact_id' "manifest_aws_${ARCH}.json" \
+            | tr ',' '\n' | grep "^${TEST_REGION}:" | cut -d: -f2)
+          [ -n "$ami" ] || { echo "no AMI for ${TEST_REGION} in manifest" >&2; exit 1; }
+          echo "test_ami=$ami" >> "$GITHUB_OUTPUT"
+          echo "Built ${TEST_REGION} AMI: $ami"
+
+  test:
+    name: Deploy pool onto new AMI and run the test stack
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      NEW_AMI: ${{ needs.build.outputs.test_ami }}
+    steps:
+      - name: Setup spacectl
+        uses: spacelift-io/setup-spacectl@main
+
+      - name: Point the workerpool stack at the new AMI
+        run: spacectl stack environment setvar --id "$WORKERPOOL_STACK" TF_VAR_ami_id "$NEW_AMI"
+
+      - name: Apply the workerpool stack (updates the launch template)
+        run: spacectl stack deploy --id "$WORKERPOOL_STACK" --auto-confirm
+
+      - name: Resolve the pool's ASG name
+        id: asg
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `.value` is double-encoded (a JSON string containing quotes), so fromjson decodes it.
+          asg=$(spacectl stack outputs --id "$WORKERPOOL_STACK" --output json \
+            | jq -r '.[] | select(.id=="asg_name") | .value | fromjson')
+          [ -n "$asg" ] || { echo "asg_name output not found" >&2; exit 1; }
+          echo "asg_name=$asg" >> "$GITHUB_OUTPUT"
+          echo "ASG: $asg"
+
+      - name: Configure GovCloud AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ env.TEST_REGION }}
+          role-to-assume: ${{ vars.GOVCLOUD_PRIVATE_WORKER_POOL_AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 3600
+
+      - name: Verify the ASG launch template is on the new AMI
+        # Sanity check before cycling: resolve the exact launch-template version the
+        # ASG references and confirm its ImageId is the AMI we just built, so we know
+        # the instance refresh will actually test the new image and not an old one.
+        env:
+          ASG_NAME: ${{ steps.asg.outputs.asg_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          lt=$(aws autoscaling describe-auto-scaling-groups \
+            --auto-scaling-group-names "$ASG_NAME" \
+            --query 'AutoScalingGroups[0].LaunchTemplate.[LaunchTemplateId,Version]' --output text)
+          lt_id=$(printf '%s' "$lt" | cut -f1)
+          lt_ver=$(printf '%s' "$lt" | cut -f2)
+          lt_ami=$(aws ec2 describe-launch-template-versions \
+            --launch-template-id "$lt_id" --versions "$lt_ver" \
+            --query 'LaunchTemplateVersions[0].LaunchTemplateData.ImageId' --output text)
+          echo "LT $lt_id v$lt_ver -> $lt_ami (expected $NEW_AMI)"
+          [ "$lt_ami" = "$NEW_AMI" ] || { echo "ASG launch template is NOT on the new AMI" >&2; exit 1; }
+
+      - name: Cycle the worker onto the new AMI (ASG instance refresh)
+        uses: spacelift-io/public-shared-actions/actions/refresh-workerpool-asg@main
+        with:
+          asg_name: ${{ steps.asg.outputs.asg_name }}
+          aws_region: ${{ env.TEST_REGION }}
+          min_healthy_percentage: 0
+          instance_warmup_seconds: 0
+
+      - name: Run the test stack
+        run: spacectl stack deploy --id "$TEST_STACK" --auto-confirm


### PR DESCRIPTION
Temporary PR to exercise `job_build_publish-aws-govcloud.yml` end to end (build + on-pool test, us-gov-west-1, x86_64, no publish). Not for merge — the test workflow is removed before the gov feature merges to main.