### PR TITLE
feat: Validate Azure worker image on a worker pool before publishing

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -60,54 +60,12 @@ jobs:
       timestamp: ${{ needs.timestamp.outputs.timestamp }}
 
   azure:
-    name: Build Azure AMI using Packer
-    runs-on: ubuntu-latest
+    name: Build/test/publish Azure image
     permissions:
       id-token: write
       contents: read
-    env:
-      PKR_VAR_client_id: "976e4a6e-c619-417e-9add-50e2d674e2db"
-      PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-      PKR_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      PKR_VAR_image_resource_group: rg-worker_images-public-westeurope
-      PKR_VAR_packer_work_group: rg-worker_images_packer-public-westeurope
-      PKR_VAR_gallery_resource_group: rg-worker_images-public-westeurope
-      PKR_VAR_gallery_name: spacelift_worker_images_public
-      PKR_VAR_gallery_image_name: spacelift_worker_image_ubu_lts
-      PKR_VAR_gallery_replication_regions: '["northeurope", "westeurope", "norwayeast", "uksouth", "francecentral", "germanywestcentral", "swedencentral", "northcentralus", "centralus", "eastus", "eastus2", "southcentralus", "westus2", "westus3", "canadacentral", "brazilsouth", "southeastasia", "eastasia", "centralindia", "australiaeast"]'
-      PKR_VAR_gallery_image_version: 3.0.${{ github.run_number }}
-
-    steps:
-      - name: Check out the source code
-        uses: actions/checkout@main
-
-      - name: Setup packer
-        uses: hashicorp/setup-packer@main
-        with:
-          version: latest
-
-      - name: Initialize Packer
-        run: packer init azure.pkr.hcl
-        env:
-          PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
-
-      - name: Azure => Build the AMI using Packer
-        run: packer build azure.pkr.hcl
-
-      - name: Upload manifest
-        uses: actions/upload-artifact@v7
-        with:
-          path: manifest_azure.json
-          name: manifest_azure.json
-          retention-days: 5
-
-      - name: Export Azure version number
-        id: export_azure_version
-        run: |
-          echo "azure_version=$PKR_VAR_gallery_image_version" >> $GITHUB_OUTPUT
-
-    outputs:
-      azure_version: ${{ steps.export_azure_version.outputs.azure_version }}
+    uses: ./.github/workflows/job_build_publish-azure.yml
+    secrets: inherit
 
   gcp:
     name: Build GCP AMI using Packer

--- a/.github/workflows/job_build_publish-azure.yml
+++ b/.github/workflows/job_build_publish-azure.yml
@@ -18,7 +18,6 @@ env:
   GALLERY_RG: rg-worker_images-public-westeurope
   GALLERY_NAME: spacelift_worker_images_public
   GALLERY_IMAGE: spacelift_worker_image_ubu_lts
-  COMMUNITY_GALLERY: spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079
 
 jobs:
   build:
@@ -28,7 +27,6 @@ jobs:
       id-token: write
       contents: read
     env:
-      PKR_VAR_client_id: "976e4a6e-c619-417e-9add-50e2d674e2db"
       PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
       PKR_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       PKR_VAR_image_resource_group: rg-worker_images-public-westeurope
@@ -58,6 +56,9 @@ jobs:
           PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
 
       - name: Build the Azure image (PRIVATE — excluded from latest)
+        # Single source of truth for the SP client id (job-level env can't reference the env context).
+        env:
+          PKR_VAR_client_id: ${{ env.AZURE_CLIENT_ID }}
         run: packer build azure.pkr.hcl
 
       - name: Upload manifest
@@ -83,7 +84,7 @@ jobs:
       SPACELIFT_API_KEY_ID: ${{ vars.SPACELIFT_OIDC_API_KEY_ID }}
       # The exact just-built version, pinned via the community gallery (it is excluded
       # from 'latest' but still deployable by explicit version).
-      NEW_IMAGE: /communityGalleries/spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079/images/spacelift_worker_image_ubu_lts/versions/3.0.${{ github.run_number }}
+      NEW_IMAGE: /communityGalleries/spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079/images/spacelift_worker_image_ubu_lts/versions/${{ needs.build.outputs.azure_version }}
     steps:
       - name: Setup spacectl
         uses: spacelift-io/setup-spacectl@main
@@ -100,9 +101,6 @@ jobs:
           token=$(spacectl profile export-token)
           echo "::add-mask::$token"
           echo "SPACELIFT_API_TOKEN=$token" >> "$GITHUB_ENV"
-
-      - name: Keep the workerpool stack's image var in sync (no apply — az does the swap)
-        run: spacectl stack environment setvar --id "$WORKERPOOL_STACK" TF_VAR_source_image_id "$NEW_IMAGE"
 
       - name: Resolve the pool's VMSS name and worker-pool id
         id: pool
@@ -140,6 +138,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # The swap is az-only; we deliberately do NOT setvar the stack's TF_VAR_source_image_id, so a
+          # failed test never pins the pool's terraform config to the bad version — a later apply of the
+          # (test-only) stack just reverts the pool to its default image.
           az vmss update -g "$TEST_RG" -n "$VMSS_NAME" \
             --set virtualMachineProfile.storageProfile.imageReference.communityGalleryImageId="$NEW_IMAGE"
           
@@ -218,9 +219,6 @@ jobs:
   publish:
     name: Promote the image to 'latest'
     needs: [build, test]
-    # Promote only if the build succeeded AND the on-pool test passed. On test failure the
-    # version stays excluded from 'latest' — customers tracking 'latest' never receive it.
-    if: ${{ always() && needs.build.result == 'success' && needs.test.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/job_build_publish-azure.yml
+++ b/.github/workflows/job_build_publish-azure.yml
@@ -130,7 +130,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ids=$(spacectl workerpool worker list --pool-id "${{ steps.pool.outputs.pool_id }}" --output json | jq -r '[.[].id] | join(",")')
+          ids=$(spacectl workerpool worker list --pool-id "${{ steps.pool.outputs.pool_id }}" --output json | jq -r '[ (. // []) | .[].id ] | join(",")')
           echo "ids=$ids" >> "$GITHUB_OUTPUT"
           echo "workers before reimage: [$ids]"
 
@@ -193,13 +193,13 @@ jobs:
             # A fresh worker: id NOT in the pre-reimage snapshot AND not busy.
             new_idle=$(echo "$json" | jq -r --arg before "$BEFORE" '
               ($before | split(",")) as $old
-              | [ .[] | select(.busy == false) | select((.id as $i | $old | index($i)) | not) | .id ]
+              | [ (. // []) | .[] | select(.busy == false) | select((.id as $i | $old | index($i)) | not) | .id ]
               | .[0] // empty')
           
             # Any pre-reimage (old) worker still registered? Must reach 0 to avoid running on it.
             old_left=$(echo "$json" | jq -r --arg before "$BEFORE" '
               ($before | split(",")) as $old
-              | [ .[] | select(.id as $i | $old | index($i)) ] | length')
+              | [ (. // []) | .[] | select(.id as $i | $old | index($i)) ] | length')
             echo "new_idle=[$new_idle] old_still_present=$old_left"
           
             if [ -n "$new_idle" ] && [ "$old_left" = "0" ]; then

--- a/.github/workflows/job_build_publish-azure.yml
+++ b/.github/workflows/job_build_publish-azure.yml
@@ -1,0 +1,168 @@
+on:
+  workflow_call:
+    outputs:
+      azure_version:
+        description: "The published gallery image version."
+        value: ${{ jobs.build.outputs.azure_version }}
+
+name: Build, test and publish Azure image
+
+env:
+  SPACELIFT_API_KEY_ENDPOINT: https://spacelift-ci-gh.app.spacelift.dev
+  WORKERPOOL_STACK: ami-build-resilience-workerpool-azure
+  TEST_STACK: ami-resilience-testing-azure
+  # sp-packer app (the build identity; also has Virtual Machine Contributor on the test pool RG).
+  AZURE_CLIENT_ID: "976e4a6e-c619-417e-9add-50e2d674e2db"
+  # Test subscription that hosts the worker-pool VMSS (distinct from the build/gallery sub).
+  TEST_SUBSCRIPTION_ID: "00eb57d2-b059-4e1f-ac2d-c10400a2cf24"
+  TEST_RG: rg-ami-resilience-azure
+  # Public compute gallery (exposed to customers via the community gallery).
+  GALLERY_RG: rg-worker_images-public-westeurope
+  GALLERY_NAME: spacelift_worker_images_public
+  GALLERY_IMAGE: spacelift_worker_image_ubu_lts
+  COMMUNITY_GALLERY: spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079
+
+jobs:
+  build:
+    name: Build the Azure image (excluded from latest)
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      PKR_VAR_client_id: "976e4a6e-c619-417e-9add-50e2d674e2db"
+      PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      PKR_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      PKR_VAR_image_resource_group: rg-worker_images-public-westeurope
+      PKR_VAR_packer_work_group: rg-worker_images_packer-public-westeurope
+      PKR_VAR_gallery_resource_group: rg-worker_images-public-westeurope
+      PKR_VAR_gallery_name: spacelift_worker_images_public
+      PKR_VAR_gallery_image_name: spacelift_worker_image_ubu_lts
+      PKR_VAR_gallery_replication_regions: '["northeurope", "westeurope", "norwayeast", "uksouth", "francecentral", "germanywestcentral", "swedencentral", "northcentralus", "centralus", "eastus", "eastus2", "southcentralus", "westus2", "westus3", "canadacentral", "brazilsouth", "southeastasia", "eastasia", "centralindia", "australiaeast"]'
+      PKR_VAR_gallery_image_version: 3.0.${{ github.run_number }}
+      # Publish excluded from 'latest' so customers who track 'latest' never see the
+      # untested version. Promoted (flag cleared) only after the on-pool test passes.
+      PKR_VAR_exclude_from_latest: true
+    outputs:
+      azure_version: ${{ steps.export_azure_version.outputs.azure_version }}
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@main
+
+      - name: Setup packer
+        uses: hashicorp/setup-packer@main
+        with:
+          version: latest
+
+      - name: Initialize Packer
+        run: packer init azure.pkr.hcl
+        env:
+          PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
+
+      - name: Build the Azure image (PRIVATE — excluded from latest)
+        run: packer build azure.pkr.hcl
+
+      - name: Upload manifest
+        uses: actions/upload-artifact@v7
+        with:
+          path: manifest_azure.json
+          name: manifest_azure.json
+          retention-days: 5
+
+      - name: Export Azure version number
+        id: export_azure_version
+        run: echo "azure_version=$PKR_VAR_gallery_image_version" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Cycle the pool onto the new image and run the test stack
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      SPACELIFT_API_KEY_ID: ${{ vars.SPACELIFT_OIDC_API_KEY_ID }}
+      # The exact just-built version, pinned via the community gallery (it is excluded
+      # from 'latest' but still deployable by explicit version).
+      NEW_IMAGE: /communityGalleries/spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079/images/spacelift_worker_image_ubu_lts/versions/3.0.${{ github.run_number }}
+    steps:
+      - name: Setup spacectl
+        uses: spacelift-io/setup-spacectl@main
+
+      - name: Authenticate to Spacelift via OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Declare/assign separately so `set -e` catches a failed token fetch (SC2155).
+          SPACELIFT_API_KEY_SECRET=$(curl -sf \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=spacelift-ci-gh.app.spacelift.dev" | jq -r '.value')
+          export SPACELIFT_API_KEY_SECRET
+          token=$(spacectl profile export-token)
+          echo "::add-mask::$token"
+          echo "SPACELIFT_API_TOKEN=$token" >> "$GITHUB_ENV"
+
+      - name: Point the workerpool stack at the new image
+        run: spacectl stack environment setvar --id "$WORKERPOOL_STACK" TF_VAR_source_image_id "$NEW_IMAGE"
+
+      - name: Apply the workerpool stack (updates the VMSS model)
+        run: spacectl stack deploy --id "$WORKERPOOL_STACK" --auto-confirm
+
+      - name: Resolve the pool's VMSS name
+        id: vmss
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `.value` is double-encoded (a JSON string containing quotes), so fromjson decodes it.
+          vmss=$(spacectl stack outputs --id "$WORKERPOOL_STACK" --output json \
+            | jq -r '.[] | select(.id=="vmss_name") | .value | fromjson')
+          [ -n "$vmss" ] || { echo "vmss_name output not found" >&2; exit 1; }
+          echo "vmss_name=$vmss" >> "$GITHUB_OUTPUT"
+          echo "VMSS: $vmss"
+
+      - name: Log in to Azure (Test subscription) via OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.TEST_SUBSCRIPTION_ID }}
+
+      - name: Cycle the worker onto the new image (reimage the VMSS instance)
+        env:
+          VMSS_NAME: ${{ steps.vmss.outputs.vmss_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Manual upgrade mode: apply the latest model to the instance, then reimage so it
+          # re-provisions (re-runs cloud-init) on the new image and re-registers the worker.
+          az vmss update-instances -g "$TEST_RG" -n "$VMSS_NAME" --instance-ids '*'
+          az vmss reimage          -g "$TEST_RG" -n "$VMSS_NAME" --instance-ids '*'
+
+      - name: Run the test stack (waits for the reimaged worker to pick it up)
+        run: spacectl stack deploy --id "$TEST_STACK" --auto-confirm
+
+  publish:
+    name: Promote the image to 'latest'
+    needs: [build, test]
+    # Promote only if the build succeeded AND the on-pool test passed. On test failure the
+    # version stays excluded from 'latest' — customers tracking 'latest' never receive it.
+    if: ${{ always() && needs.build.result == 'success' && needs.test.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Log in to Azure (build/gallery subscription) via OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Clear excludeFromLatest (promote to latest)
+        run: |
+          az sig image-version update \
+            -g "$GALLERY_RG" -r "$GALLERY_NAME" -i "$GALLERY_IMAGE" \
+            -e "${{ needs.build.outputs.azure_version }}" \
+            --set publishingProfile.excludeFromLatest=false

--- a/.github/workflows/job_build_publish-azure.yml
+++ b/.github/workflows/job_build_publish-azure.yml
@@ -11,9 +11,7 @@ env:
   SPACELIFT_API_KEY_ENDPOINT: https://spacelift-ci-gh.app.spacelift.dev
   WORKERPOOL_STACK: ami-build-resilience-workerpool-azure
   TEST_STACK: ami-resilience-testing-azure
-  # sp-packer app (the build identity; also has Virtual Machine Contributor on the test pool RG).
   AZURE_CLIENT_ID: "976e4a6e-c619-417e-9add-50e2d674e2db"
-  # Test subscription that hosts the worker-pool VMSS (distinct from the build/gallery sub).
   TEST_SUBSCRIPTION_ID: "00eb57d2-b059-4e1f-ac2d-c10400a2cf24"
   TEST_RG: rg-ami-resilience-azure
   # Public compute gallery (exposed to customers via the community gallery).
@@ -103,23 +101,22 @@ jobs:
           echo "::add-mask::$token"
           echo "SPACELIFT_API_TOKEN=$token" >> "$GITHUB_ENV"
 
-      - name: Point the workerpool stack at the new image
+      - name: Keep the workerpool stack's image var in sync (no apply — az does the swap)
         run: spacectl stack environment setvar --id "$WORKERPOOL_STACK" TF_VAR_source_image_id "$NEW_IMAGE"
 
-      - name: Apply the workerpool stack (updates the VMSS model)
-        run: spacectl stack deploy --id "$WORKERPOOL_STACK" --auto-confirm
-
-      - name: Resolve the pool's VMSS name
-        id: vmss
+      - name: Resolve the pool's VMSS name and worker-pool id
+        id: pool
         shell: bash
         run: |
           set -euo pipefail
           # `.value` is double-encoded (a JSON string containing quotes), so fromjson decodes it.
-          vmss=$(spacectl stack outputs --id "$WORKERPOOL_STACK" --output json \
-            | jq -r '.[] | select(.id=="vmss_name") | .value | fromjson')
-          [ -n "$vmss" ] || { echo "vmss_name output not found" >&2; exit 1; }
+          out=$(spacectl stack outputs --id "$WORKERPOOL_STACK" --output json)
+          vmss=$(echo "$out" | jq -r '.[] | select(.id=="vmss_name")      | .value | fromjson')
+          pid=$(echo "$out"  | jq -r '.[] | select(.id=="worker_pool_id") | .value | fromjson')
+          [ -n "$vmss" ] && [ -n "$pid" ] || { echo "vmss_name/worker_pool_id output not found" >&2; exit 1; }
           echo "vmss_name=$vmss" >> "$GITHUB_OUTPUT"
-          echo "VMSS: $vmss"
+          echo "pool_id=$pid"    >> "$GITHUB_OUTPUT"
+          echo "VMSS: $vmss  pool: $pid"
 
       - name: Log in to Azure (Test subscription) via OIDC
         uses: azure/login@v2
@@ -128,18 +125,94 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ env.TEST_SUBSCRIPTION_ID }}
 
-      - name: Cycle the worker onto the new image (reimage the VMSS instance)
-        env:
-          VMSS_NAME: ${{ steps.vmss.outputs.vmss_name }}
+      - name: Snapshot the pool's worker IDs before reimage
+        id: before
         shell: bash
         run: |
           set -euo pipefail
-          # Manual upgrade mode: apply the latest model to the instance, then reimage so it
-          # re-provisions (re-runs cloud-init) on the new image and re-registers the worker.
+          ids=$(spacectl workerpool worker list --pool-id "${{ steps.pool.outputs.pool_id }}" --output json | jq -r '[.[].id] | join(",")')
+          echo "ids=$ids" >> "$GITHUB_OUTPUT"
+          echo "workers before reimage: [$ids]"
+
+      - name: Cycle the worker onto the new image (set image via az, then reimage)
+        env:
+          VMSS_NAME: ${{ steps.pool.outputs.vmss_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          az vmss update -g "$TEST_RG" -n "$VMSS_NAME" \
+            --set virtualMachineProfile.storageProfile.imageReference.communityGalleryImageId="$NEW_IMAGE"
+          
+          # Manual upgrade mode: apply the new model to instance 0 (sets latestModelApplied=true and
+          # moves it onto the new image), then reimage so cloud-init re-runs and the worker re-registers.
           az vmss update-instances -g "$TEST_RG" -n "$VMSS_NAME" --instance-ids '*'
           az vmss reimage          -g "$TEST_RG" -n "$VMSS_NAME" --instance-ids '*'
 
-      - name: Run the test stack (waits for the reimaged worker to pick it up)
+      - name: Wait for the reimaged instance to be ready
+        env:
+          VMSS_NAME: ${{ steps.pool.outputs.vmss_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            prov=$(az vmss get-instance-view -g "$TEST_RG" -n "$VMSS_NAME" --instance-id 0 \
+              --query "statuses[?starts_with(code,'ProvisioningState/')].code | [0]" -o tsv || true)
+          
+            latest=$(az vmss list-instances -g "$TEST_RG" -n "$VMSS_NAME" \
+              --query "[?instanceId=='0'].latestModelApplied | [0]" -o tsv || true)
+          
+            echo "instance provisioning=$prov latestModelApplied=$latest"
+            [ "$prov" = "ProvisioningState/succeeded" ] && [ "$latest" = "true" ] && exit 0
+          
+            sleep 10
+          done
+          echo "instance did not reach succeeded / latest-model in time" >&2
+          exit 1
+
+      - name: Assert the VMSS is on the new image version (fail the gate if not)
+        env:
+          VMSS_NAME: ${{ steps.pool.outputs.vmss_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          got=$(az vmss show -g "$TEST_RG" -n "$VMSS_NAME" \
+            --query "virtualMachineProfile.storageProfile.imageReference.communityGalleryImageId" -o tsv)
+          echo "VMSS image: $got"
+          [ "$got" = "$NEW_IMAGE" ] || { echo "VMSS is NOT on the new image. want=$NEW_IMAGE got=$got" >&2; exit 1; }
+
+      - name: Wait for the reimaged worker (new, idle) and the old one gone
+        env:
+          BEFORE: ${{ steps.before.outputs.ids }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pool_id='${{ steps.pool.outputs.pool_id }}'
+          for _ in $(seq 1 60); do
+            json=$(spacectl workerpool worker list --pool-id "$pool_id" --output json)
+          
+            # A fresh worker: id NOT in the pre-reimage snapshot AND not busy.
+            new_idle=$(echo "$json" | jq -r --arg before "$BEFORE" '
+              ($before | split(",")) as $old
+              | [ .[] | select(.busy == false) | select((.id as $i | $old | index($i)) | not) | .id ]
+              | .[0] // empty')
+          
+            # Any pre-reimage (old) worker still registered? Must reach 0 to avoid running on it.
+            old_left=$(echo "$json" | jq -r --arg before "$BEFORE" '
+              ($before | split(",")) as $old
+              | [ .[] | select(.id as $i | $old | index($i)) ] | length')
+            echo "new_idle=[$new_idle] old_still_present=$old_left"
+          
+            if [ -n "$new_idle" ] && [ "$old_left" = "0" ]; then
+              echo "reimaged worker $new_idle is idle and pre-reimage workers are gone"
+              exit 0
+            fi
+          
+            sleep 10
+          done
+          echo "timed out waiting for the reimaged worker to register cleanly" >&2
+          exit 1
+
+      - name: Run the test stack (guaranteed on the new-image worker)
         run: spacectl stack deploy --id "$TEST_STACK" --auto-confirm
 
   publish:

--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -46,7 +46,7 @@ variable "gallery_resource_group" {
 }
 
 variable "gallery_name" {
-  type    = string
+  type = string
 }
 
 variable "gallery_image_name" {
@@ -89,6 +89,12 @@ variable "additional_tags" {
   default = {}
 }
 
+variable "exclude_from_latest" {
+  type        = bool
+  default     = false
+  description = "If true, the published gallery image version is excluded from 'latest' resolution (still deployable by explicit version). Used to hold a version back until it passes the on-pool test gate."
+}
+
 variable "packer_work_group" {
   type        = string
   default     = ""
@@ -106,11 +112,11 @@ source "azure-arm" "spacelift" {
   managed_image_resource_group_name = var.image_resource_group
 
   shared_image_gallery_destination {
-    subscription         = var.subscription_id
-    resource_group       = var.gallery_resource_group
-    gallery_name         = var.gallery_name
-    image_name           = var.gallery_image_name
-    image_version        = var.gallery_image_version
+    subscription   = var.subscription_id
+    resource_group = var.gallery_resource_group
+    gallery_name   = var.gallery_name
+    image_name     = var.gallery_image_name
+    image_version  = var.gallery_image_version
 
     dynamic target_region {
       for_each = var.gallery_replication_regions
@@ -121,6 +127,10 @@ source "azure-arm" "spacelift" {
     }
   }
 
+  # Hold the version back from `latest` until it passes the on-pool test gate.
+  # Top-level builder parameter (not inside shared_image_gallery_destination).
+  shared_gallery_image_version_exclude_from_latest = var.exclude_from_latest
+
   os_type = "Linux"
 
   image_publisher = var.source_image_publisher
@@ -129,7 +139,7 @@ source "azure-arm" "spacelift" {
 
   build_resource_group_name = var.packer_work_group
 
-  vm_size  = var.vm_size
+  vm_size = var.vm_size
 
   ssh_clear_authorized_keys = true
 

--- a/infra/stacks/workerpool-azure/keys.tf
+++ b/infra/stacks/workerpool-azure/keys.tf
@@ -1,0 +1,7 @@
+# The module requires an admin key (or password). The test pool needs no SSH
+# access, so we generate a throwaway key rather than manage one. If debugging
+# ever needs SSH, the private key is available in state.
+resource "tls_private_key" "admin" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}

--- a/infra/stacks/workerpool-azure/main.tf
+++ b/infra/stacks/workerpool-azure/main.tf
@@ -22,9 +22,11 @@ module "azure-worker" {
   # Launcher is pulled from downloads.<domain_name>; preprod lives on spacelift.dev.
   domain_name = "spacelift.dev"
 
-  # Keep a mis-bootstrapped VM up (instead of the default Reboot crash-loop) so a
-  # broken image can be investigated during bring-up.
   process_exit_behavior = "Reboot"
+
+  # Skip apt unattended-upgrade on boot: it adds minutes to every boot, which slows
+  # the reimage/cycle step in the test gate. The image under test is what we validate.
+  perform_unattended_upgrade_on_boot = false
 
   configuration = <<-EOT
     export SPACELIFT_TOKEN=${spacelift_worker_pool.this.config}

--- a/infra/stacks/workerpool-azure/main.tf
+++ b/infra/stacks/workerpool-azure/main.tf
@@ -1,0 +1,39 @@
+resource "spacelift_worker_pool" "this" {
+  name        = "ami-build-resilience-workerpool-azure"
+  description = "Azure VMSS pool for validating Spacelift Worker images before they are published, driven by https://github.com/spacelift-io/spacelift-worker-image (ami-resilience). Autoscaler disabled."
+  space_id    = "root" # else the API defaults the pool to the "legacy" space, invisible to a root stack
+}
+
+module "azure-worker" {
+  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool?ref=v3.0.0"
+
+  resource_group   = azurerm_resource_group.this
+  subnet_id        = azurerm_subnet.worker.id
+  identity_type    = "SystemAssigned"
+  admin_public_key = base64encode(tls_private_key.admin.public_key_openssh)
+
+  worker_pool_id  = spacelift_worker_pool.this.id
+  source_image_id = var.source_image_id # image under test; defaults to community-gallery latest
+
+  non_autoscaled_vmss_instances = 1
+  vmss_sku                      = "Standard_B2S"
+  name_prefix                   = "ami-res-azure"
+
+  # Launcher is pulled from downloads.<domain_name>; preprod lives on spacelift.dev.
+  domain_name = "spacelift.dev"
+
+  # Keep a mis-bootstrapped VM up (instead of the default Reboot crash-loop) so a
+  # broken image can be investigated during bring-up.
+  process_exit_behavior = "Reboot"
+
+  configuration = <<-EOT
+    export SPACELIFT_TOKEN=${spacelift_worker_pool.this.config}
+    export SPACELIFT_POOL_PRIVATE_KEY=${spacelift_worker_pool.this.private_key}
+    export SPACELIFT_WORKER_COMMS_PROTOCOL="poll"
+    export SPACELIFT_WORKER_COMMS_URL="https://app.spacelift.dev"
+  EOT
+
+  tags = {
+    purpose = "ami-resilience-azure-test"
+  }
+}

--- a/infra/stacks/workerpool-azure/network.tf
+++ b/infra/stacks/workerpool-azure/network.tf
@@ -1,0 +1,23 @@
+resource "azurerm_resource_group" "this" {
+  name     = "rg-ami-resilience-azure"
+  location = var.location
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "ami-res-azure-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+resource "azurerm_subnet" "worker" {
+  name                 = "worker"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  # Explicit opt-in to default outbound: the worker is egress-only (pulls from
+  # Spacelift + downloads.spacelift.dev) and nothing allowlists its source IP.
+  # Azure is retiring the implicit default for new subnets, so we set it here.
+  default_outbound_access_enabled = true
+}

--- a/infra/stacks/workerpool-azure/outputs.tf
+++ b/infra/stacks/workerpool-azure/outputs.tf
@@ -1,0 +1,20 @@
+output "worker_pool_id" {
+  value       = spacelift_worker_pool.this.id
+  description = "The Spacelift worker pool ID."
+}
+
+output "resource_group" {
+  value       = azurerm_resource_group.this.name
+  description = "The resource group holding the VMSS."
+}
+
+# Consumed by the cycle step to reimage the scale set onto a new image.
+output "vmss_name" {
+  value       = module.azure-worker.vmss_name
+  description = "The name of the Virtual Machine Scale Set."
+}
+
+output "vmss_id" {
+  value       = module.azure-worker.vmss_id
+  description = "The ID of the Virtual Machine Scale Set."
+}

--- a/infra/stacks/workerpool-azure/providers.tf
+++ b/infra/stacks/workerpool-azure/providers.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    spacelift = {
+      source  = "spacelift-io/spacelift"
+      version = "~> 1.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.42"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# In-Spacelift runs use the auto-injected SPACELIFT_API_TOKEN, so no explicit
+# credentials are needed. The stack's role must allow managing worker pools.
+provider "spacelift" {}
+
+# Auth to Azure via the attached Spacelift Azure cloud integration, which injects
+# ARM_CLIENT_ID / ARM_CLIENT_SECRET / ARM_TENANT_ID / ARM_SUBSCRIPTION_ID into the run.
+provider "azurerm" {
+  features {}
+
+  # The integration's service principal is not granted rights to register resource
+  # providers; the Test subscription already has Microsoft.Compute/Network registered.
+  resource_provider_registrations = "none"
+}

--- a/infra/stacks/workerpool-azure/stack.tf
+++ b/infra/stacks/workerpool-azure/stack.tf
@@ -1,0 +1,12 @@
+resource "spacelift_stack" "test" {
+  name        = "ami-resilience-testing-azure"
+  description = "Runs on the Azure worker pool to validate the Azure worker image before publish (ami-resilience). Bound to ami-build-resilience-workerpool-azure."
+
+  repository = "ami-resilience-testing"
+  branch     = "main"
+  space_id   = "root"
+
+  worker_pool_id = spacelift_worker_pool.this.id
+
+  autodeploy = true
+}

--- a/infra/stacks/workerpool-azure/variables.tf
+++ b/infra/stacks/workerpool-azure/variables.tf
@@ -1,0 +1,11 @@
+variable "source_image_id" {
+  type        = string
+  description = "Gallery image version under test. Override per run; defaults to the current community-gallery latest."
+  default     = "/communityGalleries/spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079/images/spacelift_worker_image/versions/latest"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the test pool."
+  default     = "westeurope"
+}

--- a/infra/stacks/workerpool-azure/variables.tf
+++ b/infra/stacks/workerpool-azure/variables.tf
@@ -1,7 +1,7 @@
 variable "source_image_id" {
   type        = string
-  description = "Gallery image version under test. Override per run; defaults to the current community-gallery latest."
-  default     = "/communityGalleries/spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079/images/spacelift_worker_image/versions/latest"
+  description = "Gallery image version under test. Override per run (the workflow pins the just-built version); defaults to the current ubu_lts line's latest. NOTE: the actively-built definition is spacelift_worker_image_ubu_lts (3.0.x), not the stale spacelift_worker_image (2.0.x)."
+  default     = "/communityGalleries/spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079/images/spacelift_worker_image_ubu_lts/versions/latest"
 }
 
 variable "location" {


### PR DESCRIPTION
## Description of the change

Adds a **test-before-publish gate for the Azure worker image**. The image is built **excluded from `latest`**, validated on a real worker pool, and **promoted to `latest`** only if the on-pool test passes.

**How it works** — `job_build_publish-azure.yml` (reusable, called by `build_scheduled.yml`):
1. **Build** the gallery image version with `exclude_from_latest=true`, so customers tracking `latest` never see an untested version.
2. **Cycle** the test pool onto the new version — `az vmss update` (image ref) → `update-instances` → `reimage` — then **assert** the VMSS is on the just-built version and **wait** for a fresh idle worker to register (guards against testing the old image or an old/draining worker).
3. **Run** the test stack (`ami-resilience-testing-azure`) on that worker.
4. **Promote** on success (clear `excludeFromLatest`); on failure the version stays excluded.

**Why `exclude_from_latest`:** Azure has no AMI-style private→public toggle — the compute gallery is surfaced to customers via a community gallery. Publishing excluded-from-latest holds the version back from `latest` (the module default) while keeping it launchable by explicit version for the test.



**Testing:** validated end-to-end with a temporary PR-triggered workflow
Example run:  https://github.com/spacelift-io/spacelift-worker-image/actions/runs/31185375588/job/92894195915#logs

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected; (Azure gallery image version built + validated on the test pool — see Testing)

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
