### PR TITLE
feat(ci): use OIDC for the commercial AMI test job's Spacelift auth

### DIFF
--- a/.github/workflows/job_build_publish-aws.yml
+++ b/.github/workflows/job_build_publish-aws.yml
@@ -91,12 +91,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
-      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
-      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      SPACELIFT_API_KEY_ID: ${{ vars.SPACELIFT_OIDC_API_KEY_ID }}
       NEW_AMI: ${{ needs.build.outputs.test_ami }}
     steps:
       - name: Setup spacectl
         uses: spacelift-io/setup-spacectl@main
+
+      - name: Authenticate to Spacelift via OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Declare/assign separately so `set -e` catches a failed token fetch (SC2155).
+          SPACELIFT_API_KEY_SECRET=$(curl -sf \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=spacelift-ci-gh.app.spacelift.dev" | jq -r '.value')
+          export SPACELIFT_API_KEY_SECRET
+          token=$(spacectl profile export-token)
+          echo "::add-mask::$token"
+          echo "SPACELIFT_API_TOKEN=$token" >> "$GITHUB_ENV"
 
       - name: Point the workerpool stack at the new AMI
         run: spacectl stack environment setvar --id "$WORKERPOOL_STACK" TF_VAR_ami_id "$NEW_AMI"


### PR DESCRIPTION
## Description of the change

The GovCloud AMI workflow (`job_build_publish-aws-govcloud.yml`) already federates to Spacelift via GitHub OIDC. The commercial workflow (`job_build_publish-aws.yml`) still used a static `SPACELIFT_API_KEY_SECRET`. This switches the commercial `test` job to the same OIDC token exchange, so no long-lived Spacelift key is needed.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

> Validation pending: the OIDC exchange will be exercised on the `wojciechp/ami-testing-testing` branch's test workflow before merge. The change mirrors the already-working gov OIDC path.

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
