### PR TITLE
fix: AWS provider resolution for worker pool stack

### DIFF
--- a/infra/stacks/workerpool-aws-gov/providers.tf
+++ b/infra/stacks/workerpool-aws-gov/providers.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.40"
+      version = ">= 6.56"
     }
   }
 }

--- a/infra/stacks/workerpool-aws/providers.tf
+++ b/infra/stacks/workerpool-aws/providers.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.40"
+      version = ">= 6.56"
     }
   }
 }


### PR DESCRIPTION
## Description of the change

The worker pool test stacks are failing to apply because of a conflict between the version constraints defined by the stacks and the worker pool modules that they use:

```
Could not resolve provider hashicorp/aws: no available releases match the
given constraints >= 6.0.0, ~> 6.40.0, >= 6.56.0
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [ ] An AMI has been created in some AWS account, and the AMI is working as expected;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
