### PR TITLE
feat: validate the GCP worker image before publishing it

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -68,73 +68,12 @@ jobs:
     secrets: inherit
 
   gcp:
-    name: Build GCP AMI using Packer
-    runs-on: ubuntu-latest
+    name: Build/test/publish GCP image
     permissions:
       id-token: write
       contents: read
-    env:
-      PKR_VAR_project_id: spacelift-workers
-      PKR_VAR_credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
-      PKR_VAR_image_base_name: spacelift-worker
-      PKR_VAR_image_family: spacelift-worker
-
-    steps:
-      - name: Check out the source code
-        uses: actions/checkout@main
-
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
-
-      - name: Authenticate with GCP
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
-
-      - name: Export suffix for GCP
-        run: |
-          echo "PKR_VAR_suffix=$(date +%s)-$(cat /dev/urandom | tr -dc 'a-z0-9' | head -c 8)" >> $GITHUB_ENV
-
-      - name: Setup packer
-        uses: hashicorp/setup-packer@main
-        with:
-          version: latest
-
-      - name: Initialize Packer
-        run: packer init gcp.pkr.hcl
-        env:
-          PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
-
-      - name: GCP => Build the AMI using Packer for US
-        run: packer build gcp.pkr.hcl
-        env:
-          PKR_VAR_image_storage_location: us
-          PKR_VAR_zone: us-central1-a
-
-      - name: GCP => Build the AMI using Packer for EU
-        run: packer build gcp.pkr.hcl
-        env:
-          PKR_VAR_image_storage_location: eu
-          PKR_VAR_zone: europe-west1-d
-
-      - name: GCP => Build the AMI using Packer for Asia
-        run: packer build gcp.pkr.hcl
-        env:
-          PKR_VAR_image_storage_location: asia
-          PKR_VAR_zone: asia-northeast2-b
-
-      - name: GCP => Add IAM policy binding to the Compute Engine images
-        run: |
-          gcloud compute images add-iam-policy-binding ${PKR_VAR_image_base_name}-us-${PKR_VAR_suffix} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
-          gcloud compute images add-iam-policy-binding ${PKR_VAR_image_base_name}-eu-${PKR_VAR_suffix} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
-          gcloud compute images add-iam-policy-binding ${PKR_VAR_image_base_name}-asia-${PKR_VAR_suffix} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
-
-      - name: Upload manifest
-        uses: actions/upload-artifact@v7
-        with:
-          path: manifest_gcp.json
-          name: manifest_gcp.json
-          retention-days: 5
+    uses: ./.github/workflows/job_build_publish-gcp.yml
+    secrets: inherit
 
   gh-release:
     needs: [aws, aws-govcloud, azure, gcp]

--- a/.github/workflows/job_build_publish-gcp.yml
+++ b/.github/workflows/job_build_publish-gcp.yml
@@ -1,0 +1,237 @@
+on:
+  workflow_call:
+
+name: Build, test and publish GCP image
+
+env:
+  GCP_PROJECT: spacelift-workers
+  IMAGE_BASE_NAME: spacelift-worker
+  SPACELIFT_API_KEY_ENDPOINT: https://spacelift-ci-gh.app.spacelift.dev
+  WORKERPOOL_STACK: ami-build-resilience-workerpool-gcp
+  TEST_STACK: ami-resilience-testing-gcp
+  RUN_SA: sl-workerpool-gcp@spacelift-development.iam.gserviceaccount.com
+  WORKER_SA: spacelift-test-worker@spacelift-development.iam.gserviceaccount.com
+  # Google APIs service agent for spacelift-development (project 316393406309)
+  CLOUDSERVICES_SA: 316393406309@cloudservices.gserviceaccount.com
+
+jobs:
+  build:
+    name: Build private images (us/eu/asia)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      PKR_VAR_project_id: spacelift-workers
+      PKR_VAR_credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+      PKR_VAR_image_base_name: spacelift-worker
+      PKR_VAR_image_family: spacelift-worker
+    outputs:
+      image_us: ${{ steps.capture.outputs.image_us }}
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@main
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+
+      - name: Export suffix for GCP
+        run: echo "PKR_VAR_suffix=$(date +%s)-$(cat /dev/urandom | tr -dc 'a-z0-9' | head -c 8)" >> "$GITHUB_ENV"
+
+      - name: Setup packer
+        uses: hashicorp/setup-packer@main
+        with:
+          version: latest
+
+      - name: Initialize Packer
+        run: packer init gcp.pkr.hcl
+        env:
+          PACKER_GITHUB_API_TOKEN: ${{ github.token }}
+
+      # Build PRIVATE: packer adds no sharing, and we deliberately skip the
+      # allAuthenticatedUsers binding here — the publish job adds it only after the test passes.
+      - name: GCP => Build the image for US
+        run: packer build gcp.pkr.hcl
+        env:
+          PKR_VAR_image_storage_location: us
+          PKR_VAR_zone: us-central1-a
+
+      - name: GCP => Build the image for EU
+        run: packer build gcp.pkr.hcl
+        env:
+          PKR_VAR_image_storage_location: eu
+          PKR_VAR_zone: europe-west1-d
+
+      - name: GCP => Build the image for Asia
+        run: packer build gcp.pkr.hcl
+        env:
+          PKR_VAR_image_storage_location: asia
+          PKR_VAR_zone: asia-northeast2-b
+
+      - name: Capture the us image path
+        id: capture
+        run: |
+          set -euo pipefail
+          echo "image_us=projects/${GCP_PROJECT}/global/images/${IMAGE_BASE_NAME}-us-${PKR_VAR_suffix}" >> "$GITHUB_OUTPUT"
+          echo "us image: ${IMAGE_BASE_NAME}-us-${PKR_VAR_suffix}"
+
+      # Grant the identities that read the still-private us image during the cycle:
+      #  - RUN_SA          creates the instance template (needs compute.images.useReadOnly)
+      #  - CLOUDSERVICES_SA is the GCE service agent that creates the MIG instances
+      #  - WORKER_SA        runtime identity of the VMs
+      - name: Share the private us image with the test identities
+        run: |
+          set -euo pipefail
+          us_image="${IMAGE_BASE_NAME}-us-${PKR_VAR_suffix}"
+          for sa in "$RUN_SA" "$CLOUDSERVICES_SA" "$WORKER_SA"; do
+            gcloud compute images add-iam-policy-binding "$us_image" \
+              --project="$GCP_PROJECT" \
+              --member="serviceAccount:${sa}" \
+              --role="roles/compute.imageUser"
+          done
+
+      - name: Upload manifest
+        uses: actions/upload-artifact@v7
+        with:
+          path: manifest_gcp.json
+          name: manifest_gcp.json
+          retention-days: 5
+
+  test:
+    name: Cycle the pool onto the new image and run the test stack
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      SPACELIFT_API_KEY_ID: ${{ vars.SPACELIFT_OIDC_API_KEY_ID }}
+      NEW_IMAGE: ${{ needs.build.outputs.image_us }}
+    steps:
+      - name: Setup spacectl
+        uses: spacelift-io/setup-spacectl@main
+
+      - name: Authenticate to Spacelift via OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Declare/assign separately so `set -e` catches a failed token fetch (SC2155).
+          SPACELIFT_API_KEY_SECRET=$(curl -sf \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=spacelift-ci-gh.app.spacelift.dev" | jq -r '.value')
+          export SPACELIFT_API_KEY_SECRET
+          token=$(spacectl profile export-token)
+          echo "::add-mask::$token"
+          echo "SPACELIFT_API_TOKEN=$token" >> "$GITHUB_ENV"
+
+      - name: Resolve the pool id
+        id: pool
+        shell: bash
+        run: |
+          set -euo pipefail
+          pid=$(spacectl stack outputs --id "$WORKERPOOL_STACK" --output json \
+            | jq -r '.[] | select(.id=="worker_pool_id") | .value | fromjson')
+          [ -n "$pid" ] || { echo "worker_pool_id output not found" >&2; exit 1; }
+          echo "pool_id=$pid" >> "$GITHUB_OUTPUT"
+          echo "pool: $pid"
+
+      - name: Snapshot the pool's worker IDs before the cycle
+        id: before
+        shell: bash
+        run: |
+          set -euo pipefail
+          ids=$(spacectl workerpool worker list --pool-id "${{ steps.pool.outputs.pool_id }}" --output json | jq -r '[ (. // []) | .[].id ] | join(",")')
+          echo "ids=$ids" >> "$GITHUB_OUTPUT"
+          echo "workers before cycle: [$ids]"
+
+      - name: Point the pool at the new image
+        run: spacectl stack environment setvar --id "$WORKERPOOL_STACK" TF_VAR_image "$NEW_IMAGE"
+
+      # Applying mints a new instance template; the module's update_policy
+      # (PROACTIVE/REPLACE) rolls the MIG onto it. The roll is async — the wait
+      # step below is what proves it actually happened.
+      - name: Apply the workerpool stack (rolls the MIG onto the new image)
+        run: spacectl stack deploy --id "$WORKERPOOL_STACK" --auto-confirm
+
+      - name: Wait for a worker ON THE NEW IMAGE (new, idle) and the old one gone
+        env:
+          BEFORE: ${{ steps.before.outputs.ids }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pool_id='${{ steps.pool.outputs.pool_id }}'
+          # The worker self-reports its boot image as the `gcp_image` metadata tag
+          # (set in the pool stack's configuration). Match on the image name so a
+          # worker only counts if it actually booted from the image under test —
+          # not merely that some new instance registered.
+          img="${NEW_IMAGE##*/}"
+          for _ in $(seq 1 60); do
+            json=$(spacectl workerpool worker list --pool-id "$pool_id" --output json)
+
+            # A fresh worker: id NOT in the pre-cycle snapshot, not busy, AND whose
+            # metadata carries the new image name (gcp_image tag).
+            new_idle=$(echo "$json" | jq -r --arg before "$BEFORE" --arg img "$img" '
+              ($before | split(",")) as $old
+              | [ (. // []) | .[]
+                  | select(.busy == false)
+                  | select((.id as $i | $old | index($i)) | not)
+                  | select((.metadata | tostring) | contains($img))
+                  | .id ]
+              | .[0] // empty')
+
+            # Any pre-cycle (old) worker still registered? Must reach 0 to avoid running on it.
+            old_left=$(echo "$json" | jq -r --arg before "$BEFORE" '
+              ($before | split(",")) as $old
+              | [ (. // []) | .[] | select(.id as $i | $old | index($i)) ] | length')
+            echo "new_idle_on_image=[$new_idle] old_still_present=$old_left"
+
+            if [ -n "$new_idle" ] && [ "$old_left" = "0" ]; then
+              echo "worker $new_idle is idle, booted from $img, and pre-cycle workers are gone"
+              exit 0
+            fi
+
+            sleep 10
+          done
+          echo "timed out waiting for a worker booted from $img to register cleanly" >&2
+          exit 1
+
+      # Proves a real run passes on a freshly-cycled (new-image) worker.
+      - name: Run the test stack (guaranteed on the new-image worker)
+        run: spacectl stack deploy --id "$TEST_STACK" --auto-confirm
+
+  publish:
+    name: Publish (make all images public)
+    needs: [build, test]
+    if: ${{ always() && needs.build.result == 'success' && needs.test.result == 'success' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+
+      - name: Download manifest
+        uses: actions/download-artifact@v8
+        with:
+          name: manifest_gcp.json
+
+      - name: Make each image public
+        run: |
+          set -euo pipefail
+          for name in $(jq -r '.builds[].artifact_id' manifest_gcp.json); do
+            echo "Publishing $name"
+            gcloud compute images add-iam-policy-binding "$name" \
+              --project="$GCP_PROJECT" \
+              --member="allAuthenticatedUsers" \
+              --role="roles/compute.imageUser"
+          done

--- a/infra/stacks/workerpool-gcp/main.tf
+++ b/infra/stacks/workerpool-gcp/main.tf
@@ -4,24 +4,14 @@ resource "spacelift_worker_pool" "this" {
   space_id    = "root" # else the API defaults the pool to the "legacy" space, invisible to a root stack
 }
 
-# Default to the latest public worker image when the workflow has not pinned one.
-# The images are public (allAuthenticatedUsers imageUser), so the run's integration
-# SA can read the family. NOTE: cross-project read of spacelift-workers is assumed;
-# if the run SA lacks it, pin var.image instead.
-data "google_compute_image" "latest" {
-  family  = "spacelift-worker"
-  project = "spacelift-workers"
-}
-
 locals {
-  image    = coalesce(var.image, data.google_compute_image.latest.self_link)
   mig_name = "ami-res-gcp-workers"
 }
 
 module "gcp-worker" {
   source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=v2.0.0"
 
-  image                       = local.image
+  image                       = var.image
   network                     = "default"
   region                      = var.region
   zone                        = var.zone
@@ -38,6 +28,10 @@ module "gcp-worker" {
     export SPACELIFT_POOL_PRIVATE_KEY=${spacelift_worker_pool.this.private_key}
     export SPACELIFT_WORKER_COMMS_PROTOCOL="poll"
     export SPACELIFT_WORKER_COMMS_URL="https://app.spacelift.dev"
+    # Report the boot image as a worker metadata tag (gcp_image) so the rollout
+    # workflow can assert, via the Spacelift API alone, that the cycled worker
+    # actually booted from the image under test.
+    export SPACELIFT_METADATA_gcp_image="$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/image || true)"
   EOT
 
   providers = {

--- a/infra/stacks/workerpool-gcp/main.tf
+++ b/infra/stacks/workerpool-gcp/main.tf
@@ -1,0 +1,49 @@
+resource "spacelift_worker_pool" "this" {
+  name        = "ami-build-resilience-workerpool-gcp"
+  description = "GCP MIG pool for validating Spacelift Worker images before they are published, driven by https://github.com/spacelift-io/spacelift-worker-image (ami-resilience). Autoscaler disabled."
+  space_id    = "root" # else the API defaults the pool to the "legacy" space, invisible to a root stack
+}
+
+# Default to the latest public worker image when the workflow has not pinned one.
+# The images are public (allAuthenticatedUsers imageUser), so the run's integration
+# SA can read the family. NOTE: cross-project read of spacelift-workers is assumed;
+# if the run SA lacks it, pin var.image instead.
+data "google_compute_image" "latest" {
+  family  = "spacelift-worker"
+  project = "spacelift-workers"
+}
+
+locals {
+  image    = coalesce(var.image, data.google_compute_image.latest.self_link)
+  mig_name = "ami-res-gcp-workers"
+}
+
+module "gcp-worker" {
+  source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=v2.0.0"
+
+  image                       = local.image
+  network                     = "default"
+  region                      = var.region
+  zone                        = var.zone
+  size                        = 1
+  project                     = var.project
+  email                       = var.worker_service_account_email
+  instance_group_manager_name = local.mig_name
+
+  # Launcher is pulled from downloads.<domain_name>; preprod lives on spacelift.dev.
+  domain_name = "spacelift.dev"
+
+  configuration = <<-EOT
+    export SPACELIFT_TOKEN=${spacelift_worker_pool.this.config}
+    export SPACELIFT_POOL_PRIVATE_KEY=${spacelift_worker_pool.this.private_key}
+    export SPACELIFT_WORKER_COMMS_PROTOCOL="poll"
+    export SPACELIFT_WORKER_COMMS_URL="https://app.spacelift.dev"
+  EOT
+
+  providers = {
+    google = google
+  }
+
+  # Workers have no external IP; they need NAT egress before they can register.
+  depends_on = [google_compute_router_nat.this]
+}

--- a/infra/stacks/workerpool-gcp/network.tf
+++ b/infra/stacks/workerpool-gcp/network.tf
@@ -1,0 +1,28 @@
+# The module attaches no access_config to the instance template, so the workers
+# have no external IP. They are egress-only (pull from Spacelift + downloads.spacelift.dev),
+# so we give the default network Cloud NAT for outbound. Mirrors the module's
+# examples/default-network test case.
+resource "google_compute_router" "this" {
+  name    = "ami-res-gcp-router"
+  region  = var.region
+  network = "default"
+  project = var.project
+
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_nat" "this" {
+  name                               = "ami-res-gcp-nat"
+  router                             = google_compute_router.this.name
+  region                             = var.region
+  project                            = var.project
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}

--- a/infra/stacks/workerpool-gcp/outputs.tf
+++ b/infra/stacks/workerpool-gcp/outputs.tf
@@ -1,0 +1,21 @@
+output "worker_pool_id" {
+  value       = spacelift_worker_pool.this.id
+  description = "The Spacelift worker pool ID."
+}
+
+# Consumed by the workflow's verify step (gcloud needs the MIG name + location).
+# The module exposes no outputs, so we surface the values we pass in.
+output "instance_group_manager_name" {
+  value       = local.mig_name
+  description = "Name of the zonal managed instance group backing the pool."
+}
+
+output "zone" {
+  value       = var.zone
+  description = "Zone of the managed instance group."
+}
+
+output "project" {
+  value       = var.project
+  description = "GCP project hosting the test pool."
+}

--- a/infra/stacks/workerpool-gcp/providers.tf
+++ b/infra/stacks/workerpool-gcp/providers.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    spacelift = {
+      source  = "spacelift-io/spacelift"
+      version = "~> 1.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# In-Spacelift runs use the auto-injected SPACELIFT_API_TOKEN, so no explicit
+# credentials are needed. The stack's role must allow managing worker pools.
+provider "spacelift" {}
+
+# Auth to GCP via the attached Spacelift GCP cloud integration, which injects a
+# short-lived GOOGLE_OAUTH_ACCESS_TOKEN into the run (the same mechanism the
+# module's own registry tests use). The integration's service account must be able
+# to manage Compute Engine (instance templates, MIGs, routers/NAT) in var.project.
+provider "google" {
+  project = var.project
+  region  = var.region
+}

--- a/infra/stacks/workerpool-gcp/stack.tf
+++ b/infra/stacks/workerpool-gcp/stack.tf
@@ -1,0 +1,12 @@
+resource "spacelift_stack" "test" {
+  name        = "ami-resilience-testing-gcp"
+  description = "Runs on the GCP worker pool to validate the GCP worker image before publish (ami-resilience). Bound to ami-build-resilience-workerpool-gcp."
+
+  repository = "ami-resilience-testing"
+  branch     = "main"
+  space_id   = "root"
+
+  worker_pool_id = spacelift_worker_pool.this.id
+
+  autodeploy = true
+}

--- a/infra/stacks/workerpool-gcp/variables.tf
+++ b/infra/stacks/workerpool-gcp/variables.tf
@@ -1,11 +1,12 @@
 variable "image" {
   type        = string
   description = <<-EOT
-    Full self-link/path of the worker image under test. Override per run (the
-    workflow pins the just-built image). When null, defaults to the latest
-    non-deprecated image in the public 'spacelift-worker' family.
+    Full path of the worker image the pool boots, e.g.
+    projects/spacelift-workers/global/images/spacelift-worker-us-<suffix>.
+    Required — the rollout workflow pins the just-built image per run (and it is
+    persisted on the stack env). Intentionally no family "latest" default: that
+    lookup would 403 reading a still-private newest-in-family image during the gate.
   EOT
-  default     = null
 }
 
 variable "project" {

--- a/infra/stacks/workerpool-gcp/variables.tf
+++ b/infra/stacks/workerpool-gcp/variables.tf
@@ -1,0 +1,33 @@
+variable "image" {
+  type        = string
+  description = <<-EOT
+    Full self-link/path of the worker image under test. Override per run (the
+    workflow pins the just-built image). When null, defaults to the latest
+    non-deprecated image in the public 'spacelift-worker' family.
+  EOT
+  default     = null
+}
+
+variable "project" {
+  type        = string
+  description = "GCP project that hosts the test worker pool. TODO confirm — the module's own tests use 'spacelift-development'."
+  default     = "spacelift-development"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region for the test pool (Cloud Router / NAT are regional)."
+  default     = "us-central1"
+}
+
+variable "zone" {
+  type        = string
+  description = "GCP zone for the (zonal) managed instance group."
+  default     = "us-central1-a"
+}
+
+variable "worker_service_account_email" {
+  type        = string
+  description = "Service account the worker VMs run as. TODO confirm for the chosen test project."
+  default     = "spacelift-test-worker@spacelift-development.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
## Description of the change

This brings GCP up to the same **build → test → publish** gate AWS and Azure already have: a freshly-built GCP image is only made public after a real Spacelift run passes on a worker booted from it.

- **`job_build_publish-gcp.yml`** :
  - **build** — builds the us/eu/asia images **private** and shares the `us` image with the test service accounts.
  - **test** — points the `ami-build-resilience-workerpool-gcp` pool at the new image (GitHub→Spacelift OIDC), lets the MIG roll onto it, waits for the new worker to register (and the old one to drain), then runs the `ami-resilience-testing-gcp` stack on it.
  - **publish** — makes all three images public, **only if the test passed and only on `main`**.
- **`infra/stacks/workerpool-gcp/`** — the GCP validation worker pool + bound test stack (Compute Engine MIG via `terraform-google-spacelift-workerpool`)

Auth: GitHub→GCP **Workload Identity Federation** (OIDC) for the pool runs.

Part of ami-resilience — [ClickUp 869e8q73z](https://app.clickup.com/t/869e8q73z).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] Validated on GCP (in place of the AWS-AMI check): the pool stack applies, the worker registers, and an `ami-resilience-testing-gcp` run FINISHED on the new-image worker.

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft" (kept draft until `test-rollout-gcp.yml` is removed);
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
