### PR TITLE
feat: build, test and publish ARM64 GCP worker images

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -68,12 +68,27 @@ jobs:
     secrets: inherit
 
   gcp:
-    name: Build/test/publish GCP image
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            machine_type: n1-standard-2
+            source_image_family: ubuntu-2404-lts-amd64
+          - arch: arm64
+            # T2A (Ampere Altra): the only ARM series compatible with the default
+            # pd-standard build disk (C4A is Hyperdisk-only).
+            machine_type: t2a-standard-2
+            source_image_family: ubuntu-2404-lts-arm64
+    name: Build/test/publish GCP image (${{ matrix.arch }})
     permissions:
       id-token: write
       contents: read
     uses: ./.github/workflows/job_build_publish-gcp.yml
     secrets: inherit
+    with:
+      arch: ${{ matrix.arch }}
+      machine_type: ${{ matrix.machine_type }}
+      source_image_family: ${{ matrix.source_image_family }}
 
   gh-release:
     needs: [aws, aws-govcloud, azure, gcp]
@@ -198,10 +213,15 @@ jobs:
             ]
             fs.appendFileSync("./body.md", "\n\n" + header.join("\n") + "\n" + toPrint.join("\n"));
 
-      - name: Download Google Cloud manifest
+      - name: Download Google Cloud x64 manifest
         uses: actions/download-artifact@v8
         with:
-          name: manifest_gcp.json
+          name: manifest_gcp_x86_64.json
+
+      - name: Download Google Cloud arm64 manifest
+        uses: actions/download-artifact@v8
+        with:
+          name: manifest_gcp_arm64.json
 
         # The GCP manifest file look like this:
         # "builds": [
@@ -233,22 +253,24 @@ jobs:
           script: |
             const fs = require("fs");
 
-            content = fs.readFileSync("./manifest_gcp.json", "utf8");
-            manifest = JSON.parse(content);
-
             const gcpLinesToPrint = [];
 
-            manifest["builds"].forEach((build) => {
-                    artifact = build["artifact_id"];
-                    if (artifact.indexOf("-us-") > 0) {
-                        gcpLinesToPrint.push(` - United States | \`${artifact}\``);
-                    }
-                    if (artifact.indexOf("-eu-") > 0) {
-                        gcpLinesToPrint.push(` - Europe | \`${artifact}\``);
-                    }
-                    if (artifact.indexOf("-asia-") > 0) {
-                        gcpLinesToPrint.push(` - Asia | \`${artifact}\``);
-                    }
+            [["x86_64", "./manifest_gcp_x86_64.json"], ["arm64", "./manifest_gcp_arm64.json"]].forEach(([arch, file]) => {
+                gcpLinesToPrint.push(`### ${arch}`, "");
+                const manifest = JSON.parse(fs.readFileSync(file, "utf8"));
+                manifest["builds"].forEach((build) => {
+                        const artifact = build["artifact_id"];
+                        if (artifact.indexOf("-us-") > 0) {
+                            gcpLinesToPrint.push(` - United States | \`${artifact}\``);
+                        }
+                        if (artifact.indexOf("-eu-") > 0) {
+                            gcpLinesToPrint.push(` - Europe | \`${artifact}\``);
+                        }
+                        if (artifact.indexOf("-asia-") > 0) {
+                            gcpLinesToPrint.push(` - Asia | \`${artifact}\``);
+                        }
+                });
+                gcpLinesToPrint.push("");
             });
 
             azureLines = [

--- a/.github/workflows/job_build_publish-gcp.yml
+++ b/.github/workflows/job_build_publish-gcp.yml
@@ -1,14 +1,33 @@
 on:
   workflow_call:
+    inputs:
+      arch:
+        description: "Image architecture (x86_64 or arm64)."
+        type: string
+        required: true
+      machine_type:
+        description: "Machine type for the Packer build VM. Must match the arch and exist in the build zones."
+        type: string
+        required: true
+      source_image_family:
+        description: "Public Ubuntu image family to build from (ubuntu-2404-lts-amd64 or ubuntu-2404-lts-arm64)."
+        type: string
+        required: true
 
 name: Build, test and publish GCP image
 
 env:
   GCP_PROJECT: spacelift-workers
-  IMAGE_BASE_NAME: spacelift-worker
+  # arm64 images get their own name prefix AND image family: a GCP image family
+  # resolves to its newest image regardless of architecture, so mixing arches in
+  # one family would hand x86 family-consumers an unbootable ARM image.
+  IMAGE_BASE_NAME: ${{ inputs.arch == 'arm64' && 'spacelift-worker-arm64' || 'spacelift-worker' }}
+  MANIFEST: manifest_gcp_${{ inputs.arch }}.json
   SPACELIFT_API_KEY_ENDPOINT: https://spacelift-ci-gh.app.spacelift.dev
-  WORKERPOOL_STACK: ami-build-resilience-workerpool-gcp
-  TEST_STACK: ami-resilience-testing-gcp
+  # Each arch has its own test pool + test stack, so the two matrix legs never
+  # touch each other's Spacelift stack state or cycle each other's MIG.
+  WORKERPOOL_STACK: ${{ inputs.arch == 'arm64' && 'ami-build-resilience-workerpool-gcp-arm64' || 'ami-build-resilience-workerpool-gcp' }}
+  TEST_STACK: ${{ inputs.arch == 'arm64' && 'ami-resilience-testing-gcp-arm64' || 'ami-resilience-testing-gcp' }}
   RUN_SA: sl-workerpool-gcp@spacelift-development.iam.gserviceaccount.com
   WORKER_SA: spacelift-test-worker@spacelift-development.iam.gserviceaccount.com
   # Google APIs service agent for spacelift-development (project 316393406309)
@@ -16,15 +35,18 @@ env:
 
 jobs:
   build:
-    name: Build private images (us/eu/asia)
+    name: Build private images (us/eu/asia, ${{ inputs.arch }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       PKR_VAR_project_id: spacelift-workers
       PKR_VAR_credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
-      PKR_VAR_image_base_name: spacelift-worker
-      PKR_VAR_image_family: spacelift-worker
+      PKR_VAR_image_base_name: ${{ inputs.arch == 'arm64' && 'spacelift-worker-arm64' || 'spacelift-worker' }}
+      PKR_VAR_image_family: ${{ inputs.arch == 'arm64' && 'spacelift-worker-arm64' || 'spacelift-worker' }}
+      PKR_VAR_arch: ${{ inputs.arch }}
+      PKR_VAR_machine_type: ${{ inputs.machine_type }}
+      PKR_VAR_source_image_family: ${{ inputs.source_image_family }}
     outputs:
       image_us: ${{ steps.capture.outputs.image_us }}
     steps:
@@ -54,6 +76,10 @@ jobs:
 
       # Build PRIVATE: packer adds no sharing, and we deliberately skip the
       # allAuthenticatedUsers binding here — the publish job adds it only after the test passes.
+      # ARM machine types (T2A) exist in none of the EU/Asia build zones, so the arm64
+      # leg runs all three builds from us-central1-a — the build zone only hosts the
+      # temporary build VM, while image_storage_locations still places the image's
+      # storage in us/eu/asia. The images are global either way.
       - name: GCP => Build the image for US
         run: packer build gcp.pkr.hcl
         env:
@@ -64,31 +90,58 @@ jobs:
         run: packer build gcp.pkr.hcl
         env:
           PKR_VAR_image_storage_location: eu
-          PKR_VAR_zone: europe-west1-d
+          PKR_VAR_zone: ${{ inputs.arch == 'arm64' && 'us-central1-a' || 'europe-west1-d' }}
 
       - name: GCP => Build the image for Asia
         run: packer build gcp.pkr.hcl
         env:
           PKR_VAR_image_storage_location: asia
-          PKR_VAR_zone: asia-northeast2-b
+          PKR_VAR_zone: ${{ inputs.arch == 'arm64' && 'us-central1-a' || 'asia-northeast2-b' }}
 
+      # ARM instances are UEFI-only with gVNIC networking: an arm64 image that lost the
+      # UEFI_COMPATIBLE/GVNIC guest-OS features (inherited from the source disk, but never
+      # sent by packer itself) would be unbootable everywhere. Fail here, before any
+      # test/publish, rather than shipping it.
+      - name: Verify image architecture and boot features
+        env:
+          ARCH: ${{ inputs.arch }}
+        run: |
+          set -euo pipefail
+          expected=$([ "$ARCH" = "arm64" ] && echo ARM64 || echo X86_64)
+          for name in $(jq -r '.builds[].artifact_id' "$MANIFEST"); do
+            gcloud compute images describe "$name" --project="$GCP_PROJECT" --format=json > image.json
+            actual=$(jq -r '.architecture' image.json)
+            [ "$actual" = "$expected" ] || { echo "$name: architecture=$actual, expected $expected" >&2; exit 1; }
+            if [ "$ARCH" = "arm64" ]; then
+              jq -e '[.guestOsFeatures[]?.type] | (contains(["UEFI_COMPATIBLE"]) and contains(["GVNIC"]))' image.json > /dev/null \
+                || { echo "$name is missing UEFI_COMPATIBLE/GVNIC guest OS features — unbootable on ARM" >&2; exit 1; }
+            fi
+            echo "$name: architecture=$actual OK"
+          done
+
+      # Derive the us image name from the manifest (single source of truth) instead of
+      # reconstructing it from env — a reconstruction mismatch could share/test the wrong image.
       - name: Capture the us image path
         id: capture
         run: |
           set -euo pipefail
-          echo "image_us=projects/${GCP_PROJECT}/global/images/${IMAGE_BASE_NAME}-us-${PKR_VAR_suffix}" >> "$GITHUB_OUTPUT"
-          echo "us image: ${IMAGE_BASE_NAME}-us-${PKR_VAR_suffix}"
+          us_image=$(jq -r '[.builds[].artifact_id | select(contains("-us-"))] | first // empty' "$MANIFEST")
+          [ -n "$us_image" ] || { echo "us image not found in $MANIFEST" >&2; exit 1; }
+          echo "image_us_name=$us_image" >> "$GITHUB_OUTPUT"
+          echo "image_us=projects/${GCP_PROJECT}/global/images/${us_image}" >> "$GITHUB_OUTPUT"
+          echo "us image: $us_image"
 
       # Grant the identities that read the still-private us image during the cycle:
       #  - RUN_SA          creates the instance template (needs compute.images.useReadOnly)
       #  - CLOUDSERVICES_SA is the GCE service agent that creates the MIG instances
       #  - WORKER_SA        runtime identity of the VMs
       - name: Share the private us image with the test identities
+        env:
+          US_IMAGE: ${{ steps.capture.outputs.image_us_name }}
         run: |
           set -euo pipefail
-          us_image="${IMAGE_BASE_NAME}-us-${PKR_VAR_suffix}"
           for sa in "$RUN_SA" "$CLOUDSERVICES_SA" "$WORKER_SA"; do
-            gcloud compute images add-iam-policy-binding "$us_image" \
+            gcloud compute images add-iam-policy-binding "$US_IMAGE" \
               --project="$GCP_PROJECT" \
               --member="serviceAccount:${sa}" \
               --role="roles/compute.imageUser"
@@ -97,12 +150,12 @@ jobs:
       - name: Upload manifest
         uses: actions/upload-artifact@v7
         with:
-          path: manifest_gcp.json
-          name: manifest_gcp.json
+          path: manifest_gcp_${{ inputs.arch }}.json
+          name: manifest_gcp_${{ inputs.arch }}.json
           retention-days: 5
 
   test:
-    name: Cycle the pool onto the new image and run the test stack
+    name: Cycle the ${{ inputs.arch }} pool onto the new image and run the test stack
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -205,7 +258,7 @@ jobs:
         run: spacectl stack deploy --id "$TEST_STACK" --auto-confirm
 
   publish:
-    name: Publish (make all images public)
+    name: Publish (make all ${{ inputs.arch }} images public)
     needs: [build, test]
     if: ${{ always() && needs.build.result == 'success' && needs.test.result == 'success' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
@@ -223,12 +276,12 @@ jobs:
       - name: Download manifest
         uses: actions/download-artifact@v8
         with:
-          name: manifest_gcp.json
+          name: manifest_gcp_${{ inputs.arch }}.json
 
       - name: Make each image public
         run: |
           set -euo pipefail
-          for name in $(jq -r '.builds[].artifact_id' manifest_gcp.json); do
+          for name in $(jq -r '.builds[].artifact_id' "$MANIFEST"); do
             echo "Publishing $name"
             gcloud compute images add-iam-policy-binding "$name" \
               --project="$GCP_PROJECT" \

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ crash.log
 
 # Ignore pkrvars files used for local testing
 *.pkrvars.hcl
+
+# Terraform working directories (infra/stacks are validated locally)
+.terraform/
+.terraform.lock.hcl

--- a/docs/build-test-publish.md
+++ b/docs/build-test-publish.md
@@ -110,8 +110,11 @@ Details live in `.github/workflows/job_build_publish-azure.yml`, `azure.pkr.hcl`
 
 ## GCP
 
-The published artifact is a set of three **Compute Engine images** (US, EU, Asia; amd64). What's
-specific to GCP:
+The published artifact is a set of three **Compute Engine images** (US, EU, Asia) per
+architecture (x86_64 and arm64 — six images total). arm64 images use their own name prefix
+(`spacelift-worker-arm64-…`) and image family (`spacelift-worker-arm64`): a GCP image family
+resolves to its newest image regardless of architecture, so mixing arches in one family would
+hand family-based consumers an image their machine type can't boot. What's specific to GCP:
 
 - **Public/private is an IAM binding.** Images are built project-private; publishing grants
   `allAuthenticatedUsers` the `roles/compute.imageUser` role on all three. During the test, the
@@ -119,6 +122,12 @@ specific to GCP:
 - **Only the US image is gated;** all three (identical content) publish together. The test points
   the pool at the new image and applies — the managed instance group (MIG) rolls a worker onto it,
   and that worker is confirmed to have booted from the exact image under test before the run.
+- **Both architectures are gated** on their own dedicated pool (x86_64 on an e2 MIG, arm64 on a
+  T2A MIG) — the two matrix legs share no Spacelift stack state. arm64 builds all run from
+  us-central1-a (the EU/Asia build zones offer no ARM machine types; the build zone only hosts the
+  temporary build VM — image storage locations are set independently), and a post-build check
+  asserts each arm64 image carries `architecture=ARM64` plus the `UEFI_COMPATIBLE`/`GVNIC`
+  guest-OS features before it may be tested or published.
 
-Details live in `.github/workflows/job_build_publish-gcp.yml`, `gcp.pkr.hcl`, and
-`infra/stacks/workerpool-gcp/`.
+Details live in `.github/workflows/job_build_publish-gcp.yml`, `gcp.pkr.hcl`,
+`infra/stacks/workerpool-gcp/`, and `infra/stacks/workerpool-gcp-arm64/`.

--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -44,7 +44,7 @@ variable "arch" {
 
   validation {
     condition     = contains(["x86_64", "arm64"], var.arch)
-    error_message = "arch must be x86_64 or arm64."
+    error_message = "The arch must be x86_64 or arm64."
   }
 }
 

--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -37,6 +37,17 @@ variable "source_image_family" {
   default = "ubuntu-2404-lts-amd64"
 }
 
+variable "arch" {
+  type        = string
+  default     = "x86_64"
+  description = "Target image architecture. Must match source_image_family and machine_type; stamps the produced image's architecture field and names the manifest file."
+
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.arch)
+    error_message = "arch must be x86_64 or arm64."
+  }
+}
+
 variable "suffix" {
   type    = string
   description = "A suffix to add to image names to ensure each version is unique. For example a timestamp or version number."
@@ -70,6 +81,10 @@ source "googlecompute" "spacelift" {
   image_name              = "${var.image_base_name}-${var.image_storage_location}-${var.suffix}"
   image_family            = var.image_family
   image_storage_locations = [var.image_storage_location]
+  # GCE inherits the architecture from the source disk when unset, but plugin 1.1.5
+  # once regressed that default (hashicorp/packer-plugin-googlecompute#232) and the
+  # plugin version floats (~> 1), so stamp it explicitly.
+  image_architecture = var.arch
 }
 
 build {
@@ -90,6 +105,6 @@ build {
   }
 
   post-processor "manifest" {
-    output = "manifest_gcp.json"
+    output = "manifest_gcp_${var.arch}.json"
   }
 }

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -13,3 +13,29 @@ packer build gcp.pkr.hcl
 Override the defaults using `-var="zone=europe-west1-d"`
 
 The variables are located in the `gcp.pkr.hcl` file.
+
+#### ARM64
+
+Pass the arm64 variable set (the source image family, an ARM machine type, and a zone that
+offers it — T2A exists in us-central1-a/b/f, europe-west4 and asia-southeast1; C4A is
+Hyperdisk-only and won't work with the default build disk):
+
+```shell
+packer build \
+  -var="arch=arm64" \
+  -var="source_image_family=ubuntu-2404-lts-arm64" \
+  -var="machine_type=t2a-standard-2" \
+  -var="zone=us-central1-a" \
+  gcp.pkr.hcl
+```
+
+### Consuming the images
+
+- amd64 images: `spacelift-worker-<us|eu|asia>-<suffix>`, family `spacelift-worker`.
+- arm64 images: `spacelift-worker-arm64-<us|eu|asia>-<suffix>`, family `spacelift-worker-arm64`.
+
+The families are architecture-specific on purpose — never point an x86 machine type at the
+arm64 family or vice versa. When using
+[terraform-google-spacelift-workerpool](https://github.com/spacelift-io/terraform-google-spacelift-workerpool)
+with an arm64 image, override `image` **and** `machine_type` together: the module default
+(`e2-medium`) is x86-only, so pick an ARM machine type such as `t2a-standard-2`.

--- a/infra/README.md
+++ b/infra/README.md
@@ -13,7 +13,8 @@ stacks/
   workerpool-aws/      EC2 test worker pool (ami-build-resilience-workerpool)
   workerpool-aws-gov/  GovCloud test worker pool
   workerpool-azure/    Azure VMSS test worker pool
-  workerpool-gcp/      GCP MIG test worker pool
+  workerpool-gcp/      GCP MIG test worker pool (x86_64)
+  workerpool-gcp-arm64/ GCP MIG test worker pool (arm64, T2A)
 modules/
   github-deployment-role/  GitHub-OIDC IAM role used by CI to cycle a pool
 ```

--- a/infra/stacks/workerpool-gcp-arm64/main.tf
+++ b/infra/stacks/workerpool-gcp-arm64/main.tf
@@ -1,0 +1,49 @@
+resource "spacelift_worker_pool" "this" {
+  name        = "ami-build-resilience-workerpool-gcp-arm64"
+  description = "GCP ARM64 (T2A) MIG pool for validating arm64 Spacelift Worker images before they are published, driven by https://github.com/spacelift-io/spacelift-worker-image (ami-resilience). Autoscaler disabled."
+  space_id    = "root" # else the API defaults the pool to the "legacy" space, invisible to a root stack
+}
+
+locals {
+  mig_name = "ami-res-gcp-arm64-workers"
+}
+
+module "gcp-worker" {
+  source = "github.com/spacelift-io/terraform-google-spacelift-workerpool?ref=v2.0.0"
+
+  image = var.image
+  # The module default (e2-medium) is x86-only; an ARM64 image can't boot on it.
+  # T2A is the ARM series that works with the module's default Persistent Disk
+  # (C4A is Hyperdisk-only) and is offered in us-central1-a.
+  machine_type                = "t2a-standard-1"
+  network                     = "default"
+  region                      = var.region
+  zone                        = var.zone
+  size                        = 1
+  project                     = var.project
+  email                       = var.worker_service_account_email
+  instance_group_manager_name = local.mig_name
+
+  # Launcher is pulled from downloads.<domain_name>; preprod lives on spacelift.dev.
+  # The module's startup script downloads spacelift-launcher-$(uname -m), so ARM
+  # workers fetch the aarch64 binary automatically.
+  domain_name = "spacelift.dev"
+
+  configuration = <<-EOT
+    export SPACELIFT_TOKEN=${spacelift_worker_pool.this.config}
+    export SPACELIFT_POOL_PRIVATE_KEY=${spacelift_worker_pool.this.private_key}
+    export SPACELIFT_WORKER_COMMS_PROTOCOL="poll"
+    export SPACELIFT_WORKER_COMMS_URL="https://app.spacelift.dev"
+    # Report the boot image as a worker metadata tag (gcp_image) so the rollout
+    # workflow can assert, via the Spacelift API alone, that the cycled worker
+    # actually booted from the image under test.
+    export SPACELIFT_METADATA_gcp_image="$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/image || true)"
+  EOT
+
+  providers = {
+    google = google
+  }
+
+  # Workers have no external IP; they need NAT egress before they can register.
+  depends_on = [google_compute_router_nat.this]
+}

--- a/infra/stacks/workerpool-gcp-arm64/network.tf
+++ b/infra/stacks/workerpool-gcp-arm64/network.tf
@@ -1,0 +1,31 @@
+# The module attaches no access_config to the instance template, so the workers
+# have no external IP. They are egress-only (pull from Spacelift + downloads.spacelift.dev),
+# so we give the default network Cloud NAT for outbound.
+#
+# Deliberately duplicated from workerpool-gcp (with renamed resources) rather than
+# shared: the two stacks must never depend on each other's state, so an arm64-side
+# apply failure can never break the amd64 publish gate (and vice versa).
+resource "google_compute_router" "this" {
+  name    = "ami-res-gcp-arm64-router"
+  region  = var.region
+  network = "default"
+  project = var.project
+
+  bgp {
+    asn = 64515
+  }
+}
+
+resource "google_compute_router_nat" "this" {
+  name                               = "ami-res-gcp-arm64-nat"
+  router                             = google_compute_router.this.name
+  region                             = var.region
+  project                            = var.project
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}

--- a/infra/stacks/workerpool-gcp-arm64/outputs.tf
+++ b/infra/stacks/workerpool-gcp-arm64/outputs.tf
@@ -1,0 +1,21 @@
+output "worker_pool_id" {
+  value       = spacelift_worker_pool.this.id
+  description = "The Spacelift worker pool ID."
+}
+
+# Consumed by the workflow's verify step (gcloud needs the MIG name + location).
+# The module exposes no outputs, so we surface the values we pass in.
+output "instance_group_manager_name" {
+  value       = local.mig_name
+  description = "Name of the zonal managed instance group backing the pool."
+}
+
+output "zone" {
+  value       = var.zone
+  description = "Zone of the managed instance group."
+}
+
+output "project" {
+  value       = var.project
+  description = "GCP project hosting the test pool."
+}

--- a/infra/stacks/workerpool-gcp-arm64/providers.tf
+++ b/infra/stacks/workerpool-gcp-arm64/providers.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    spacelift = {
+      source  = "spacelift-io/spacelift"
+      version = "~> 1.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# In-Spacelift runs use the auto-injected SPACELIFT_API_TOKEN, so no explicit
+# credentials are needed. The stack's role must allow managing worker pools.
+provider "spacelift" {}
+
+# Auth to GCP via the attached Spacelift GCP cloud integration, which injects a
+# short-lived GOOGLE_OAUTH_ACCESS_TOKEN into the run (the same mechanism the
+# module's own registry tests use). The integration's service account must be able
+# to manage Compute Engine (instance templates, MIGs, routers/NAT) in var.project.
+provider "google" {
+  project = var.project
+  region  = var.region
+}

--- a/infra/stacks/workerpool-gcp-arm64/stack.tf
+++ b/infra/stacks/workerpool-gcp-arm64/stack.tf
@@ -1,0 +1,12 @@
+resource "spacelift_stack" "test" {
+  name        = "ami-resilience-testing-gcp-arm64"
+  description = "Runs on the GCP arm64 worker pool to validate the arm64 GCP worker image before publish (ami-resilience). Bound to ami-build-resilience-workerpool-gcp-arm64."
+
+  repository = "ami-resilience-testing"
+  branch     = "main"
+  space_id   = "root"
+
+  worker_pool_id = spacelift_worker_pool.this.id
+
+  autodeploy = true
+}

--- a/infra/stacks/workerpool-gcp-arm64/variables.tf
+++ b/infra/stacks/workerpool-gcp-arm64/variables.tf
@@ -1,0 +1,34 @@
+variable "image" {
+  type        = string
+  description = <<-EOT
+    Full path of the arm64 worker image the pool boots, e.g.
+    projects/spacelift-workers/global/images/spacelift-worker-arm64-us-<suffix>.
+    Required — the rollout workflow pins the just-built image per run (and it is
+    persisted on the stack env). Intentionally no family "latest" default: that
+    lookup would 403 reading a still-private newest-in-family image during the gate.
+  EOT
+}
+
+variable "project" {
+  type        = string
+  description = "GCP project that hosts the test worker pool."
+  default     = "spacelift-development"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region for the test pool (Cloud Router / NAT are regional)."
+  default     = "us-central1"
+}
+
+variable "zone" {
+  type        = string
+  description = "GCP zone for the (zonal) managed instance group. Must offer T2A machine types (us-central1-a/b/f)."
+  default     = "us-central1-a"
+}
+
+variable "worker_service_account_email" {
+  type        = string
+  description = "Service account the worker VMs run as."
+  default     = "spacelift-test-worker@spacelift-development.iam.gserviceaccount.com"
+}

--- a/shared/scripts/apt-install-docker.sh
+++ b/shared/scripts/apt-install-docker.sh
@@ -12,7 +12,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o 
 
 # Setup the Docker APT repository
 echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 sudo apt-get -y update


### PR DESCRIPTION
Adds an arm64 leg to the GCP worker image pipeline (requested by xAI — ClickUp 869ec5gxr). Mirrors the AWS arch-matrix pattern, but **fully gated**: arm64 images are boot-tested on their own dedicated T2A worker pool before publishing, instead of shipping untested like AWS arm64 does.

## What changed

- **`shared/scripts/apt-install-docker.sh`** — Now uses `$(dpkg --print-architecture)` to get the arch.
- **`gcp.pkr.hcl`** — new `arch` variable (default `x86_64`): stamps `image_architecture` explicitly (guards against a repeat of hashicorp/packer-plugin-googlecompute#232, since the plugin version floats on `~> 1`) and names the manifest `manifest_gcp_<arch>.json`.
- **`job_build_publish-gcp.yml`** — now takes `arch` / `machine_type` / `source_image_family` inputs:
  - arm64 builds all three storage locations (us/eu/asia) from **us-central1-a** — T2A doesn't exist in europe-west1-d or asia-northeast2-b, and the build zone only hosts the temporary build VM; `image_storage_locations` is independent.
  - arm64 images get their own name prefix and **image family** (`spacelift-worker-arm64`) — a GCP family resolves to its newest image regardless of architecture, so sharing the family would hand x86 family-consumers an unbootable ARM image. amd64 names/family are byte-identical to today.
  - New post-build verify step: asserts `architecture` on every image, plus `UEFI_COMPATIBLE`/`GVNIC` guest-OS features on arm64 (ARM GCE is UEFI-only — a missing feature means an unbootable image; this fails before test/publish).
  - The us image name is derived from the manifest via jq instead of being reconstructed from env.
  - Each arch tests on its own pool/test stack (`ami-build-resilience-workerpool-gcp[-arm64]`, `ami-resilience-testing-gcp[-arm64]`) — the matrix legs share no Spacelift stack state.
- **`build_scheduled.yml`** — GCP is a 2-leg matrix (x86_64 on n1-standard-2, arm64 on t2a-standard-2); the release notes now render per-arch GCP subsections from the two manifests.
- **`infra/stacks/workerpool-gcp-arm64/`** — dedicated arm64 test pool: `t2a-standard-1` MIG, own router/NAT (renamed, deliberately not shared), own test stack. A separate stack by design so an arm64-side apply failure can never break the amd64 publish gate.
- Docs: `docs/build-test-publish.md`, `gcp/README.md` (arm64 build recipe + the image+machine_type pairing rule for module consumers), `infra/README.md`.

--- 
After merging, run **`build_scheduled` via workflow_dispatch once** rather than waiting for the Sunday cron — `gh-release` has `needs` on all clouds without `always()`, so an unrehearsed arm64 failure would suppress the weekly release for every cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)