### PR TITLE
feat: rotate launcher logs so long-lived workers cannot fill disk

### DIFF
--- a/aws.pkr.hcl
+++ b/aws.pkr.hcl
@@ -167,6 +167,7 @@ build {
       "shared/scripts/data-directories.sh",
       "aws/scripts/dnf-update.sh",
       "aws/scripts/system-deps.sh",
+      "shared/scripts/logrotate.sh",
       "aws/scripts/docker.sh",
       "shared/scripts/gvisor.sh",
       "aws/scripts/cloudwatch-agent.sh",

--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -159,6 +159,7 @@ build {
     scripts = [
       "shared/scripts/data-directories.sh",
       "shared/scripts/apt-update.sh",
+      "shared/scripts/logrotate.sh",
       "shared/scripts/apt-install-docker.sh",
       "shared/scripts/gvisor.sh",
       "shared/scripts/apt-install-jq.sh",

--- a/gcp.pkr.hcl
+++ b/gcp.pkr.hcl
@@ -94,6 +94,7 @@ build {
     scripts = [
       "shared/scripts/data-directories.sh",
       "shared/scripts/apt-update.sh",
+      "shared/scripts/logrotate.sh",
       "shared/scripts/apt-install-docker.sh",
       "shared/scripts/gvisor.sh",
       "shared/scripts/apt-install-jq.sh",

--- a/shared/scripts/logrotate.sh
+++ b/shared/scripts/logrotate.sh
@@ -1,0 +1,29 @@
+# Rotate launcher logs so long-lived workers cannot fill the root volume.
+# copytruncate is required: the launcher (and the AWS CloudWatch agent) keep
+# these files open, so a rename-and-create rotate would not free disk.
+
+if command -v dnf >/dev/null 2>&1; then
+  sudo dnf install -y logrotate
+elif command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get -y install logrotate
+else
+  echo "No supported package manager found to install logrotate" >&2
+  exit 1
+fi
+
+sudo tee /etc/logrotate.d/spacelift >/dev/null <<'EOF'
+/var/log/spacelift/*.log {
+    daily
+    maxsize 100M
+    rotate 5
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}
+EOF
+
+if [ -f /usr/lib/systemd/system/logrotate.timer ] || [ -f /lib/systemd/system/logrotate.timer ]; then
+  sudo systemctl enable --now logrotate.timer
+fi


### PR DESCRIPTION
## Description of the change

Adds log rotate to not break worker

From issue:

> The Spacelift worker writes logs to disk on the EC2 instance (e.g. spacelift-info.log and spacelift-errors.log, referenced in cloudwatch.tf and shipped to CloudWatch via the awslogs agent baked into the worker AMI). There is currently nothing that rotates these files on disk, so on long-lived workers they can grow unbounded and eventually fill the root volume.

Fixes spacelift-io/terraform-aws-spacelift-workerpool-on-ec2#224