### PR TITLE
 fix: cycle the Azure worker pool by replacing the VMSS instance

### DIFF
--- a/.github/workflows/job_build_publish-azure.yml
+++ b/.github/workflows/job_build_publish-azure.yml
@@ -200,23 +200,7 @@ jobs:
           echo "OK: exactly one worker, booted image_version=$got"
 
       - name: Run the test stack (guaranteed on the new-image worker)
-        shell: bash
-        run: |
-          set -uo pipefail
-          run_test() {
-            spacectl stack deploy --id "$TEST_STACK" --auto-confirm 2>&1 | tee /tmp/run.log
-            return "${PIPESTATUS[0]}"
-          }
-          if run_test; then echo "test stack passed"; exit 0; fi
-          # Defensive one-shot retry for a transient worker-heartbeat loss; a real image regression
-          # fails deterministically on both attempts and is still caught.
-          if grep -q "worker stopped reporting its status" /tmp/run.log; then
-            echo "::warning::test failed with 'worker stopped reporting its status' — retrying once"
-            run_test && { echo "test stack passed on retry"; exit 0; }
-            echo "test failed again after retry" >&2; exit 1
-          fi
-          echo "test failed for a non-transient reason — not retrying" >&2
-          exit 1
+        run: spacectl stack deploy --id "$TEST_STACK" --auto-confirm
 
   publish:
     name: Promote the image to 'latest'

--- a/.github/workflows/job_build_publish-azure.yml
+++ b/.github/workflows/job_build_publish-azure.yml
@@ -179,31 +179,25 @@ jobs:
         run: |
           set -euo pipefail
           pool_id='${{ steps.pool.outputs.pool_id }}'
-          # Bounded readiness wait for the single replacement worker to register (registration is
-          # async). Break only once the pool has exactly one worker AND it self-reports the image under
-          # test — otherwise a stale worker still listed during the scale-in grace period could be
-          # accepted while the new one hasn't registered yet, failing the assert on a good image.
-          json='[]'
+          # Bounded readiness wait for the single replacement worker (registration is async). Succeed
+          # only once the pool has exactly one worker AND it self-reports the image under test (the
+          # `image_version` tag, set in the pool stack config from IMDS exactVersion) — otherwise a
+          # stale worker still listed during the scale-in grace period could be accepted while the new
+          # one hasn't registered yet.
           for _ in $(seq 1 60); do
-            json=$(spacectl workerpool worker list --pool-id "$pool_id" --output json)
-            if [ "$(echo "$json" | jq 'length')" = "1" ] \
-               && [ "$(echo "$json" | jq -r '.[0].metadata.image_version // "MISSING"')" = "$EXPECTED_VERSION" ]; then
-              break
+            json=$(spacectl workerpool worker list --pool-id "$pool_id" --output json) || json='[]'
+            count=$(echo "$json" | jq 'length')
+            got=$(echo "$json" | jq -r '.[0].metadata.image_version // "MISSING"')
+            if [ "$count" = "1" ] && [ "$got" = "$EXPECTED_VERSION" ]; then
+              echo "OK: exactly one worker, booted image_version=$got"
+              exit 0
             fi
-            echo "workers=$(echo "$json" | jq 'length'), waiting for the single replacement worker on image $EXPECTED_VERSION..."
+            echo "count=$count image_version=$got, waiting for the replacement worker on $EXPECTED_VERSION..."
             sleep 10
           done
-          echo "final worker list: $(echo "$json" | jq -c '[ .[] | {id, busy, metadata} ]')"
-
-          count=$(echo "$json" | jq 'length')
-          [ "$count" = "1" ] || { echo "expected exactly 1 worker, got $count" >&2; exit 1; }
-
-          # The worker self-reports its booted image as the `image_version` tag (set in the pool stack
-          # config from IMDS exactVersion). Assert it is the version we just built, so we can only run on
-          # a worker actually booted from the image under test.
-          got=$(echo "$json" | jq -r '.[0].metadata.image_version // "MISSING"')
-          [ "$got" = "$EXPECTED_VERSION" ] || { echo "worker image_version=$got, expected $EXPECTED_VERSION" >&2; exit 1; }
-          echo "OK: exactly one worker, booted image_version=$got"
+          echo "final worker list: $(echo "$json" | jq -c '[ .[] | {id, busy, metadata} ]')" >&2
+          echo "timed out: last saw count=$count image_version=$got, expected exactly 1 on $EXPECTED_VERSION" >&2
+          exit 1
 
       - name: Run the test stack (guaranteed on the new-image worker)
         run: spacectl stack deploy --id "$TEST_STACK" --auto-confirm

--- a/.github/workflows/job_build_publish-azure.yml
+++ b/.github/workflows/job_build_publish-azure.yml
@@ -179,12 +179,18 @@ jobs:
         run: |
           set -euo pipefail
           pool_id='${{ steps.pool.outputs.pool_id }}'
-          # Bounded readiness wait for the single replacement worker to register (registration is async).
+          # Bounded readiness wait for the single replacement worker to register (registration is
+          # async). Break only once the pool has exactly one worker AND it self-reports the image under
+          # test — otherwise a stale worker still listed during the scale-in grace period could be
+          # accepted while the new one hasn't registered yet, failing the assert on a good image.
           json='[]'
           for _ in $(seq 1 60); do
             json=$(spacectl workerpool worker list --pool-id "$pool_id" --output json)
-            [ "$(echo "$json" | jq 'length')" = "1" ] && break
-            echo "workers=$(echo "$json" | jq 'length'), waiting for the single replacement worker..."
+            if [ "$(echo "$json" | jq 'length')" = "1" ] \
+               && [ "$(echo "$json" | jq -r '.[0].metadata.image_version // "MISSING"')" = "$EXPECTED_VERSION" ]; then
+              break
+            fi
+            echo "workers=$(echo "$json" | jq 'length'), waiting for the single replacement worker on image $EXPECTED_VERSION..."
             sleep 10
           done
           echo "final worker list: $(echo "$json" | jq -c '[ .[] | {id, busy, metadata} ]')"

--- a/.github/workflows/job_build_publish-azure.yml
+++ b/.github/workflows/job_build_publish-azure.yml
@@ -56,7 +56,6 @@ jobs:
           PACKER_GITHUB_API_TOKEN: "${{ github.token }}"
 
       - name: Build the Azure image (PRIVATE — excluded from latest)
-        # Single source of truth for the SP client id (job-level env can't reference the env context).
         env:
           PKR_VAR_client_id: ${{ env.AZURE_CLIENT_ID }}
         run: packer build azure.pkr.hcl
@@ -129,16 +128,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # The swap is az-only; we deliberately do NOT setvar the stack's TF_VAR_source_image_id, so a
-          # failed test never pins the pool's terraform config to the bad version — a later apply of the
-          # (test-only) stack just reverts the pool to its default image.
           az vmss update -g "$TEST_RG" -n "$VMSS_NAME" \
             --set virtualMachineProfile.storageProfile.imageReference.communityGalleryImageId="$NEW_IMAGE"
 
-          # Replace the instance (scale 0 -> 1) instead of reimage-in-place. Reimage made a single VMSS
-          # instance register TWO worker sessions; a run could bind to the stale one and fail with
-          # "worker stopped reporting its status". A fresh instance boots the new model once and registers
-          # exactly one worker — matching the AWS (ASG refresh) and GCP (MIG REPLACE) gates.
           az vmss scale -g "$TEST_RG" -n "$VMSS_NAME" --new-capacity 0
           until [ "$(az vmss list-instances -g "$TEST_RG" -n "$VMSS_NAME" --query 'length(@)' -o tsv)" = "0" ]; do
             echo "waiting for scale-in to 0 instances..."; sleep 5
@@ -151,7 +143,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # The replacement instance normally reuses id 0, but don't assume — resolve it.
           for _ in $(seq 1 30); do
             iid=$(az vmss list-instances -g "$TEST_RG" -n "$VMSS_NAME" --query "[0].instanceId" -o tsv || true)
             if [ -n "$iid" ]; then
@@ -169,9 +160,6 @@ jobs:
           echo "instance did not reach succeeded / latest-model in time" >&2
           exit 1
 
-      # No separate "assert VMSS model is on the new image" step: the worker-level image_version
-      # assertion below is end-to-end (a worker can't self-report the built version unless the
-      # model, the instance, and the boot were all correct), so it subsumes a model check.
       - name: Assert exactly one worker, on the image under test
         env:
           EXPECTED_VERSION: ${{ needs.build.outputs.azure_version }}
@@ -179,11 +167,7 @@ jobs:
         run: |
           set -euo pipefail
           pool_id='${{ steps.pool.outputs.pool_id }}'
-          # Bounded readiness wait for the single replacement worker (registration is async). Succeed
-          # only once the pool has exactly one worker AND it self-reports the image under test (the
-          # `image_version` tag, set in the pool stack config from IMDS exactVersion) — otherwise a
-          # stale worker still listed during the scale-in grace period could be accepted while the new
-          # one hasn't registered yet.
+          
           for _ in $(seq 1 60); do
             json=$(spacectl workerpool worker list --pool-id "$pool_id" --output json) || json='[]'
             count=$(echo "$json" | jq 'length')

--- a/.github/workflows/job_build_publish-azure.yml
+++ b/.github/workflows/job_build_publish-azure.yml
@@ -123,16 +123,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ env.TEST_SUBSCRIPTION_ID }}
 
-      - name: Snapshot the pool's worker IDs before reimage
-        id: before
-        shell: bash
-        run: |
-          set -euo pipefail
-          ids=$(spacectl workerpool worker list --pool-id "${{ steps.pool.outputs.pool_id }}" --output json | jq -r '[ (. // []) | .[].id ] | join(",")')
-          echo "ids=$ids" >> "$GITHUB_OUTPUT"
-          echo "workers before reimage: [$ids]"
-
-      - name: Cycle the worker onto the new image (set image via az, then reimage)
+      - name: Cycle the worker onto the new image (set image via az, then replace the instance)
         env:
           VMSS_NAME: ${{ steps.pool.outputs.vmss_name }}
         shell: bash
@@ -143,78 +134,89 @@ jobs:
           # (test-only) stack just reverts the pool to its default image.
           az vmss update -g "$TEST_RG" -n "$VMSS_NAME" \
             --set virtualMachineProfile.storageProfile.imageReference.communityGalleryImageId="$NEW_IMAGE"
-          
-          # Manual upgrade mode: apply the new model to instance 0 (sets latestModelApplied=true and
-          # moves it onto the new image), then reimage so cloud-init re-runs and the worker re-registers.
-          az vmss update-instances -g "$TEST_RG" -n "$VMSS_NAME" --instance-ids '*'
-          az vmss reimage          -g "$TEST_RG" -n "$VMSS_NAME" --instance-ids '*'
 
-      - name: Wait for the reimaged instance to be ready
+          # Replace the instance (scale 0 -> 1) instead of reimage-in-place. Reimage made a single VMSS
+          # instance register TWO worker sessions; a run could bind to the stale one and fail with
+          # "worker stopped reporting its status". A fresh instance boots the new model once and registers
+          # exactly one worker — matching the AWS (ASG refresh) and GCP (MIG REPLACE) gates.
+          az vmss scale -g "$TEST_RG" -n "$VMSS_NAME" --new-capacity 0
+          until [ "$(az vmss list-instances -g "$TEST_RG" -n "$VMSS_NAME" --query 'length(@)' -o tsv)" = "0" ]; do
+            echo "waiting for scale-in to 0 instances..."; sleep 5
+          done
+          az vmss scale -g "$TEST_RG" -n "$VMSS_NAME" --new-capacity 1
+
+      - name: Wait for the new instance to be ready
         env:
           VMSS_NAME: ${{ steps.pool.outputs.vmss_name }}
         shell: bash
         run: |
           set -euo pipefail
+          # The replacement instance normally reuses id 0, but don't assume — resolve it.
           for _ in $(seq 1 30); do
-            prov=$(az vmss get-instance-view -g "$TEST_RG" -n "$VMSS_NAME" --instance-id 0 \
-              --query "statuses[?starts_with(code,'ProvisioningState/')].code | [0]" -o tsv || true)
-          
-            latest=$(az vmss list-instances -g "$TEST_RG" -n "$VMSS_NAME" \
-              --query "[?instanceId=='0'].latestModelApplied | [0]" -o tsv || true)
-          
-            echo "instance provisioning=$prov latestModelApplied=$latest"
-            [ "$prov" = "ProvisioningState/succeeded" ] && [ "$latest" = "true" ] && exit 0
-          
+            iid=$(az vmss list-instances -g "$TEST_RG" -n "$VMSS_NAME" --query "[0].instanceId" -o tsv || true)
+            if [ -n "$iid" ]; then
+              prov=$(az vmss get-instance-view -g "$TEST_RG" -n "$VMSS_NAME" --instance-id "$iid" \
+                --query "statuses[?starts_with(code,'ProvisioningState/')].code | [0]" -o tsv || true)
+              latest=$(az vmss list-instances -g "$TEST_RG" -n "$VMSS_NAME" \
+                --query "[?instanceId=='$iid'].latestModelApplied | [0]" -o tsv || true)
+              echo "instance $iid provisioning=$prov latestModelApplied=$latest"
+              [ "$prov" = "ProvisioningState/succeeded" ] && [ "$latest" = "true" ] && exit 0
+            else
+              echo "no instance yet (scale-up in progress)"
+            fi
             sleep 10
           done
           echo "instance did not reach succeeded / latest-model in time" >&2
           exit 1
 
-      - name: Assert the VMSS is on the new image version (fail the gate if not)
+      # No separate "assert VMSS model is on the new image" step: the worker-level image_version
+      # assertion below is end-to-end (a worker can't self-report the built version unless the
+      # model, the instance, and the boot were all correct), so it subsumes a model check.
+      - name: Assert exactly one worker, on the image under test
         env:
-          VMSS_NAME: ${{ steps.pool.outputs.vmss_name }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          got=$(az vmss show -g "$TEST_RG" -n "$VMSS_NAME" \
-            --query "virtualMachineProfile.storageProfile.imageReference.communityGalleryImageId" -o tsv)
-          echo "VMSS image: $got"
-          [ "$got" = "$NEW_IMAGE" ] || { echo "VMSS is NOT on the new image. want=$NEW_IMAGE got=$got" >&2; exit 1; }
-
-      - name: Wait for the reimaged worker (new, idle) and the old one gone
-        env:
-          BEFORE: ${{ steps.before.outputs.ids }}
+          EXPECTED_VERSION: ${{ needs.build.outputs.azure_version }}
         shell: bash
         run: |
           set -euo pipefail
           pool_id='${{ steps.pool.outputs.pool_id }}'
+          # Bounded readiness wait for the single replacement worker to register (registration is async).
+          json='[]'
           for _ in $(seq 1 60); do
             json=$(spacectl workerpool worker list --pool-id "$pool_id" --output json)
-          
-            # A fresh worker: id NOT in the pre-reimage snapshot AND not busy.
-            new_idle=$(echo "$json" | jq -r --arg before "$BEFORE" '
-              ($before | split(",")) as $old
-              | [ (. // []) | .[] | select(.busy == false) | select((.id as $i | $old | index($i)) | not) | .id ]
-              | .[0] // empty')
-          
-            # Any pre-reimage (old) worker still registered? Must reach 0 to avoid running on it.
-            old_left=$(echo "$json" | jq -r --arg before "$BEFORE" '
-              ($before | split(",")) as $old
-              | [ (. // []) | .[] | select(.id as $i | $old | index($i)) ] | length')
-            echo "new_idle=[$new_idle] old_still_present=$old_left"
-          
-            if [ -n "$new_idle" ] && [ "$old_left" = "0" ]; then
-              echo "reimaged worker $new_idle is idle and pre-reimage workers are gone"
-              exit 0
-            fi
-          
+            [ "$(echo "$json" | jq 'length')" = "1" ] && break
+            echo "workers=$(echo "$json" | jq 'length'), waiting for the single replacement worker..."
             sleep 10
           done
-          echo "timed out waiting for the reimaged worker to register cleanly" >&2
-          exit 1
+          echo "final worker list: $(echo "$json" | jq -c '[ .[] | {id, busy, metadata} ]')"
+
+          count=$(echo "$json" | jq 'length')
+          [ "$count" = "1" ] || { echo "expected exactly 1 worker, got $count" >&2; exit 1; }
+
+          # The worker self-reports its booted image as the `image_version` tag (set in the pool stack
+          # config from IMDS exactVersion). Assert it is the version we just built, so we can only run on
+          # a worker actually booted from the image under test.
+          got=$(echo "$json" | jq -r '.[0].metadata.image_version // "MISSING"')
+          [ "$got" = "$EXPECTED_VERSION" ] || { echo "worker image_version=$got, expected $EXPECTED_VERSION" >&2; exit 1; }
+          echo "OK: exactly one worker, booted image_version=$got"
 
       - name: Run the test stack (guaranteed on the new-image worker)
-        run: spacectl stack deploy --id "$TEST_STACK" --auto-confirm
+        shell: bash
+        run: |
+          set -uo pipefail
+          run_test() {
+            spacectl stack deploy --id "$TEST_STACK" --auto-confirm 2>&1 | tee /tmp/run.log
+            return "${PIPESTATUS[0]}"
+          }
+          if run_test; then echo "test stack passed"; exit 0; fi
+          # Defensive one-shot retry for a transient worker-heartbeat loss; a real image regression
+          # fails deterministically on both attempts and is still caught.
+          if grep -q "worker stopped reporting its status" /tmp/run.log; then
+            echo "::warning::test failed with 'worker stopped reporting its status' — retrying once"
+            run_test && { echo "test stack passed on retry"; exit 0; }
+            echo "test failed again after retry" >&2; exit 1
+          fi
+          echo "test failed for a non-transient reason — not retrying" >&2
+          exit 1
 
   publish:
     name: Promote the image to 'latest'

--- a/infra/stacks/workerpool-azure/main.tf
+++ b/infra/stacks/workerpool-azure/main.tf
@@ -33,9 +33,10 @@ module "azure-worker" {
     export SPACELIFT_POOL_PRIVATE_KEY=${spacelift_worker_pool.this.private_key}
     export SPACELIFT_WORKER_COMMS_PROTOCOL="poll"
     export SPACELIFT_WORKER_COMMS_URL="https://app.spacelift.dev"
-    # Self-report the booted image version as a worker metadata tag (like GCP's gcp_image), so the
+    # Self-report the booted image version as a worker metadata tag, so the
     # test gate can assert the worker actually booted the image under test. `exactVersion` resolves
     # "latest" to the concrete gallery version (e.g. 3.0.122); needs IMDS api-version >= 2023-07-01.
+    # Uses metadata service, docs: https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service
     export SPACELIFT_METADATA_image_version="$(curl -s -H Metadata:true --noproxy '*' 'http://169.254.169.254/metadata/instance/compute/storageProfile/imageReference?api-version=2023-07-01' | jq -r '.exactVersion // "unknown"')"
   EOT
 

--- a/infra/stacks/workerpool-azure/main.tf
+++ b/infra/stacks/workerpool-azure/main.tf
@@ -33,6 +33,10 @@ module "azure-worker" {
     export SPACELIFT_POOL_PRIVATE_KEY=${spacelift_worker_pool.this.private_key}
     export SPACELIFT_WORKER_COMMS_PROTOCOL="poll"
     export SPACELIFT_WORKER_COMMS_URL="https://app.spacelift.dev"
+    # Self-report the booted image version as a worker metadata tag (like GCP's gcp_image), so the
+    # test gate can assert the worker actually booted the image under test. `exactVersion` resolves
+    # "latest" to the concrete gallery version (e.g. 3.0.122); needs IMDS api-version >= 2023-07-01.
+    export SPACELIFT_METADATA_image_version="$(curl -s -H Metadata:true --noproxy '*' 'http://169.254.169.254/metadata/instance/compute/storageProfile/imageReference?api-version=2023-07-01' | jq -r '.exactVersion // "unknown"')"
   EOT
 
   tags = {


### PR DESCRIPTION
## Description of the change

Updates Azure `build → test → publish` workflow. Replaces azure reimage operation with vmss scaling.
([run 34066056154](https://github.com/spacelift-io/spacelift-worker-image/actions/runs/34066056154)):
the freshly-built image was fine, but the on-pool test stack failed with
`worker stopped reporting its status`, so the image was never promoted.

**Root cause:** the gate reimaged the test VMSS **in place** (`az vmss reimage`). A single VMSS
instance then registered **two** worker sessions in Spacelift (a launcher double-registration —
confirmed: both sessions had the same `instance_id`/`vm_resource_id`). The test run bound to the
short-lived stale session, which then vanished, and the run timed out. 

Changes:
1. **Replace the instance** (`az vmss scale 0 → 1`) instead of `reimage`/`update-instances`. A fresh
   instance boots the new model once and registers exactly one worker.
2. **Assert exactly one worker, on the image under test.** The worker now self-reports its booted
   image as an `image_version` metadata tag (from Azure IMDS `exactVersion`, added to the
   `ami-build-resilience-workerpool-azure` pool config). The gate
   asserts the pool has exactly one worker **and** that its `image_version` equals the version just
   built — so the test can only run on a worker actually booted from the image under test.

**Validation:** tested end-to-end on a throwaway PR-triggered debug workflow (build a fresh
`0.0.<run>` image → scale 0→1 → assert one worker with matching `image_version` → run the test
stack). Latest green run:
[101998083823](https://github.com/spacelift-io/spacelift-worker-image/actions/runs/34206803151/job/101998083823).

Deploy note (merge ordering):
The gate depends on the `image_version` tag, which is baked into the VMSS user_data by the `ami-build-resilience-workerpool-azure` pool stack. After merge, apply that pool stack (from `main`) so the tag is present, otherwise the first scheduled run asserts `image_version=MISSING`. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The HCL code is formatted;
- [x] An AMI has been created in some AWS account, and the AMI is working as expected;
      _(Azure image validated on the test pool via the debug workflow — see run above.)_

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
